### PR TITLE
use googleapis/gnostic v0.4.0 to workaround a dependency issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ build: deps server-gen astrolabe ivd kubernetes s3repository fs server cmd
 deps:
 	go get k8s.io/klog
 	cd $(GOPATH)/src/k8s.io/klog ; git checkout v0.4.0
+	go get github.com/googleapis/gnostic
+	cd $(GOPATH)/src/github.com/googleapis/gnostic ; git checkout v0.4.0
 	go get ./...
 	go get github.com/go-swagger/go-swagger
 	go get github.com/go-swagger/go-swagger/...


### PR DESCRIPTION
The most recent commit of googleapis/gnostic on Jan 31, 2020 (https://github.com/googleapis/gnostic/commit/896953e6749863beec38e27029c804e88c3144b8), which rename some dirs from uppercase to lowercase, introduced some dependency issue. To make sure the build work properly, checking out the v0.4.0 tag of this project as a workaround.