### PR TITLE
Fix to find all shared datastores for PV provisioning in Restore

### DIFF
--- a/pkg/ivd/ivd_protected_entity_type_manager.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager.go
@@ -110,6 +110,10 @@ func NewIVDProtectedEntityTypeManagerFromURL(url *url.URL, s3URLBase string, ins
 		return nil, err
 	}
 
+	err = client.UseServiceVersion("vsan")
+	if err != nil {
+		return nil, err
+	}
 	cnsClient, err := cns.NewClient(ctx, client.Client)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix to find all shared datastores rather than all datastores for PV provisioning in the restore code path. There are a few defects for this fix.

1. The restore of storage policy is not fully supported.
2. Ruled out certain NFS datastores.
3. The process of finding eligible datastores could still be time consuming.

It should be OK for the first release though.

Signed-off-by: Lintong Jiang <lintongj@vmware.com>