### PR TITLE
Fix datacenter vm path to work if vms in folder

### DIFF
--- a/pkg/ivd/ivd_protected_entity_type_manager_util.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager_util.go
@@ -66,7 +66,7 @@ func findHostsOfNodeVMs(ctx context.Context, client *vim25.Client, config *rest.
 
 	var vmRefList []vim25types.ManagedObjectReference
 	for _, dc := range dcs {
-		path := fmt.Sprintf("%v/vm/*", dc.InventoryPath)
+		path := fmt.Sprintf("%v/vm/...", dc.InventoryPath)
 		vms, err := finder.VirtualMachineList(ctx, path)
 		if err != nil {
 			logger.WithError(err).Error("Failed to find the list of VMs in a data center")


### PR DESCRIPTION
Currently not working with vm in folder. Fix to use "..." to find vms recursively.

Reference to https://godoc.org/github.com/vmware/govmomi/find.

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>