### PR TITLE
Use the vsphere configuration passed by the plugin in IVD protected e…

### DIFF
--- a/pkg/ivd/constants.go
+++ b/pkg/ivd/constants.go
@@ -1,0 +1,13 @@
+package ivd
+
+// Keys for VCenter parameters
+const (
+	HostVcParamKey           = "VirtualCenter"
+	UserVcParamKey         = "user"
+	PasswordVcParamKey     = "password"
+	PortVcParamKey         = "port"
+	DatacenterVcParamKey   = "datacenters"
+	InsecureFlagVcParamKey = "insecure-flag"
+	ClusterVcParamKey      = "cluster-id"
+)
+

--- a/pkg/ivd/ivd_protected_entity.go
+++ b/pkg/ivd/ivd_protected_entity.go
@@ -115,8 +115,14 @@ func (this IVDProtectedEntity) getDataWriter(ctx context.Context) (io.WriteClose
 func (this IVDProtectedEntity) getDiskConnectionParams(ctx context.Context, readOnly bool) (gDiskLib.ConnectParams, error) {
 	url := this.ipetm.client.URL()
 	serverName := url.Hostname()
-	userName := this.ipetm.user
-	password := this.ipetm.password
+	userName, err := GetUserFromParamsMap(this.ipetm.vcParams)
+	if err != nil {
+		return gDiskLib.ConnectParams{}, err
+	}
+	password, err := GetPasswordFromParamsMap(this.ipetm.vcParams)
+	if err != nil {
+		return gDiskLib.ConnectParams{}, err
+	}
 	fcdId := this.id.GetID()
 	vso, err := this.ipetm.vsom.Retrieve(context.Background(), NewVimIDFromPEID(this.id))
 	if err != nil {

--- a/pkg/s3repository/repository_protected_entity_type_manager_test.go
+++ b/pkg/s3repository/repository_protected_entity_type_manager_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"github.com/vmware-tanzu/astrolabe/pkg/fs"
 	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
-	"log"
+    "log"
 	"testing"
 )
 
@@ -124,10 +124,11 @@ func TestRetrieveEntity(t *testing.T) {
 	}
 
 	ivdParams := make(map[string]interface{})
-	ivdParams["vcHost"] = "10.208.22.211:443"
-	ivdParams["insecureVC"] = "Y"
-	ivdParams["vcUser"] = "administrator@vsphere.local"
-	ivdParams["vcPassword"] = "Admin!23"
+	ivdParams[ivd.HostVcParamKey] = "10.208.22.211"
+	ivdParams[ivd.PortVcParamKey] = "443"
+	ivdParams[ivd.InsecureFlagVcParamKey] = "Y"
+	ivdParams[ivd.UserVcParamKey] = "administrator@vsphere.local"
+	ivdParams[ivd.PasswordVcParamKey] = "Admin!23"
 
 	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromConfig(ivdParams, "notUsed", logrus.New())
 	if err != nil {
@@ -195,10 +196,11 @@ func TestCopyIVDProtectedEntity(t *testing.T) {
 	}
 
 	ivdParams := make(map[string]interface{})
-	ivdParams["vcHost"] = "10.208.22.211:443"
-	ivdParams["insecureVC"] = "Y"
-	ivdParams["vcUser"] = "administrator@vsphere.local"
-	ivdParams["vcPassword"] = "Admin!23"
+	ivdParams[ivd.HostVcParamKey] = "10.208.22.211"
+	ivdParams[ivd.PortVcParamKey] = "443"
+	ivdParams[ivd.InsecureFlagVcParamKey] = "Y"
+	ivdParams[ivd.UserVcParamKey] = "administrator@vsphere.local"
+	ivdParams[ivd.PasswordVcParamKey] = "Admin!23"
 
 	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromConfig(ivdParams, "notUsed", logrus.New())
 	if err != nil {


### PR DESCRIPTION
…ntity.

The velero vsphere plugin retrieves the CSI secret to get the VC credentials
and cluster details. We can pass these as parameters to Astrolabe to avoid
retrieveing these parameters again from the cluster configuration, and keeping
to code to parse them at the plugin side.

Testing done: Tested on vanilla and TKG cluster. Backup/Restore of namespace
with PVC succeeds.
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/93/

BugID: 2565273
Jira Issue: DPCP-154

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>