### PR TITLE
Added a new PE type for PVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ export GOFLAGS=-mod=readonly
 
 all: build
 
-build: server-gen client-gen astrolabe ivd kubernetes s3repository fs server client astrolabe_server astrolabe_cli 
+build: server-gen client-gen astrolabe ivd kubernetes pvc s3repository fs server client astrolabe_server astrolabe_cli
 
 astrolabe_server: 
 	cd cmd/astrolabe_server; go build
@@ -41,6 +41,9 @@ s3repository:
 
 kubernetes: 
 	cd pkg/kubernetes; go build
+
+pvc:
+	cd pkg/pvc; go build
 
 server: 
 	cd pkg/server; go build

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,8 @@ require (
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/labstack/gommon v0.3.0
+	github.com/magiconair/properties v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/urfave/cli/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
+github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/astrolabe/protected_entity.go
+++ b/pkg/astrolabe/protected_entity.go
@@ -118,7 +118,8 @@ func (this *ProtectedEntityID) UnmarshalJSON(b []byte) error {
 	return fillInProtectedEntityIDFromString(this, idStr)
 }
 
-type ProtectedEntitySnapshotID struct {
+type
+ProtectedEntitySnapshotID struct {
 	// We should move this to actually being a UUID internally
 	id string
 }

--- a/pkg/pvc/pvc_protected_entity.go
+++ b/pkg/pvc/pvc_protected_entity.go
@@ -1,0 +1,328 @@
+package pvc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"io"
+	"io/ioutil"
+	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+/*
+PVCProtectedEntity implements a Protected Entity interface to PVCs and a basic local snapshot facility.  The PVC
+has a component PE which will be the PE that maps to the volume referenced by the PVC.  Currently IVD and para-virt PV
+are available
+
+The PVC at the time of the snapshot is serialized and stored in a config map in the namespace named
+pvc-snap.<pvc name>.  Each snapshot has an entry in the binary data map for the serialized PVC data, named by the
+snapshot ID (this is the snapshot ID returned by the subcomponent)
+ */
+
+const (
+	VSphereCSIProvisioner = "csi.vsphere.vmware.com"
+    PEInfoPrefix = "peinfo"
+)
+
+type PVCProtectedEntity struct {
+	ppetm     *PVCProtectedEntityTypeManager
+	id        astrolabe.ProtectedEntityID
+	data      []astrolabe.DataTransport
+	metadata  []astrolabe.DataTransport
+	combined  []astrolabe.DataTransport
+	logger    logrus.FieldLogger
+}
+
+func newPVCProtectedEntity(ppetm *PVCProtectedEntityTypeManager, peid astrolabe.ProtectedEntityID) (PVCProtectedEntity, error) {
+	if peid.GetPeType() != pvcPEType {
+		return PVCProtectedEntity{}, errors.Errorf("%s is not a PVC PEID", peid.String())
+	}
+	data, metadata, combined, err := ppetm.getDataTransports(peid)
+	if err != nil {
+		return PVCProtectedEntity{}, errors.Wrap(err, "Failed to get data transports")
+	}
+
+	returnPE := PVCProtectedEntity{
+		ppetm: ppetm,
+		id: peid,
+		data: data,
+		metadata: metadata,
+		combined: combined,
+		logger: ppetm.logger,
+	}
+	return returnPE, nil
+}
+
+func (this PVCProtectedEntity) GetInfo(ctx context.Context) (astrolabe.ProtectedEntityInfo, error) {
+	pvc, err := this.GetPVC()
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not retrieve PVC")
+	}
+	components, err := this.GetComponents(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not retrieve component")
+	}
+	retPEInfo := astrolabe.NewProtectedEntityInfo(this.id, pvc.Name, this.data, this.metadata, this.combined,
+		[]astrolabe.ProtectedEntityID{components[0].GetID()})
+	return retPEInfo, nil
+}
+
+func (this PVCProtectedEntity) GetCombinedInfo(ctx context.Context) ([]astrolabe.ProtectedEntityInfo, error) {
+	panic("implement me")
+}
+
+func (this PVCProtectedEntity) Snapshot(ctx context.Context) (astrolabe.ProtectedEntitySnapshotID, error) {
+	if this.id.HasSnapshot() {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.New("Cannot create snapshot of snapshot")
+	}
+	pvc, err := this.GetPVC()
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrap(err, "Could not retrieve pvc")
+	}
+	components, err := this.GetComponents(ctx)
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrap(err, "Could not retrieve components")
+	}
+	if len(components) != 1 {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.New(fmt.Sprintf("Expected 1 component, %s has %d", this.id.String(), len(components)))
+	}
+	// PVC will always have only one component, i.e., the PV it claims.
+	subSnapshotID, err := components[0].Snapshot(ctx)
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrapf(err, "Subcomponent peid %s snapshot failed", components[0].GetID())
+	}
+
+	snapConfigMapName := GetSnapConfigMapName(pvc)
+	snapConfigMap, err := this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Get(snapConfigMapName, metav1.GetOptions{})
+	var binaryData map[string][]byte
+	var create bool
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrapf(err, "Could not retrieve snapshot configmap %s for %s", snapConfigMapName,
+				this.id.String())
+		}
+
+		snapConfigMap = &core_v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:                       snapConfigMapName,
+				Namespace:                  pvc.Namespace,
+			},
+		}
+		create = true
+	} else {
+			binaryData = snapConfigMap.BinaryData
+	}
+	pvcData, err := pvc.Marshal()
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrapf(err, "Could not marshal PVC data for %v",
+			this.id.String())
+	}
+
+	if binaryData == nil {
+		binaryData = make(map[string][]byte)
+	}
+	binaryData[subSnapshotID.String()] = pvcData
+	peInfo, err := this.GetInfo(ctx)
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrapf(err, "Could not retrieve PE info for %v",
+			this.id.String())
+	}
+	peInfoData, err := json.Marshal(peInfo)
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrapf(err, "Marshal peid info %s failed", components[0].GetID())
+	}
+	binaryData[PEInfoPrefix + "-" + subSnapshotID.String()] = peInfoData
+	snapConfigMap.BinaryData = binaryData
+	if create {
+		_, err = this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Create(snapConfigMap)
+	} else {
+		_, err = this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Update(snapConfigMap)
+	}
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, errors.Wrapf(err, "PVC Snapshot write peid %s failed", components[0].GetID())
+	}
+	return subSnapshotID, nil
+}
+
+func (this PVCProtectedEntity) ListSnapshots(ctx context.Context) ([]astrolabe.ProtectedEntitySnapshotID, error) {
+	pvc, err := this.GetPVC()
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("Could not retrieve pvc peid=%s", this.id.String()))
+	}
+	snapConfigMapName := GetSnapConfigMapName(pvc)
+	snapConfigMap, err := this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Get(snapConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "Could not retrieve snapshot configmap %s for %s", snapConfigMapName,
+				this.id.String())
+		}
+		// No configmap so no snapshots
+		return []astrolabe.ProtectedEntitySnapshotID{}, nil
+	}
+	returnIDs := make([]astrolabe.ProtectedEntitySnapshotID, 0)
+	for snapshotIDStr, _ := range snapConfigMap.BinaryData {
+		if strings.Contains(snapshotIDStr, PEInfoPrefix) {
+			continue
+		}
+		returnIDs = append(returnIDs, astrolabe.NewProtectedEntitySnapshotID(snapshotIDStr))
+	}
+	return returnIDs, nil
+}
+
+func GetSnapConfigMapName(pvc *core_v1.PersistentVolumeClaim) string {
+	return "pvc-snap." + pvc.Name
+}
+
+func (this PVCProtectedEntity) DeleteSnapshot(ctx context.Context, snapshotToDelete astrolabe.ProtectedEntitySnapshotID) (bool, error) {
+	if this.id.HasSnapshot() {
+		return false, errors.New("Cannot delete snapshot of snapshot")
+	}
+	pvc, err := this.GetPVC()
+	if err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf("Could not retrieve pvc peid=%s", this.id.String()))
+	}
+	
+	snapConfigMapName := GetSnapConfigMapName(pvc)
+	snapConfigMap, err := this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Get(snapConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return false, errors.Wrapf(err, "Could not retrieve snapshot configmap %s for %s", snapConfigMapName,
+				this.id.String())
+		}
+		// No configmap so no snapshots
+		return false, nil
+	}
+
+	_, snapPVCInfoExists := snapConfigMap.BinaryData[snapshotToDelete.String()]
+	if snapPVCInfoExists {
+		delete(snapConfigMap.BinaryData, snapshotToDelete.String())
+		delete(snapConfigMap.BinaryData, "peinfo-" + snapshotToDelete.String())
+		updatedSnapConfigMap, err := this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Update(snapConfigMap)
+		if err != nil {
+			return false, errors.Wrapf(err, "Could not update snapshot configmap %s for %s", snapConfigMapName,
+				this.id.String())
+		}
+		if updatedSnapConfigMap.BinaryData == nil {
+			// no snapshot after the update. So, clean up the config map
+			var zeroSecondsGracePeriod int64
+			zeroSecondsGracePeriod = 0
+			err := this.ppetm.clientSet.CoreV1().ConfigMaps(pvc.Namespace).Delete(updatedSnapConfigMap.Name, &metav1.DeleteOptions{GracePeriodSeconds: &zeroSecondsGracePeriod})
+			if err != nil {
+				return false, errors.Wrapf(err, "Could not delete snapshot configmap %s for %s", snapConfigMapName,
+					this.id.String())
+			}
+		}
+	}
+	components, err := this.GetComponents(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "Could not retrieve components")
+	}
+	if len(components) != 1 {
+		return false, errors.New(fmt.Sprintf("Expected 1 component, %s has %d", this.id.String(), len(components)))
+	}
+	subSnapshots, err := components[0].ListSnapshots(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "Subcomponent peid %s list snapshot", components[0].GetID())
+	}
+	subsnapshotExists := false
+	for _, checkSnapshot := range subSnapshots {
+		if checkSnapshot == snapshotToDelete {
+			subsnapshotExists = true
+			break
+		}
+	}
+
+	if subsnapshotExists {
+		_, err := components[0].DeleteSnapshot(ctx, snapshotToDelete)
+		if err != nil {
+			return false, errors.Wrapf(err, "Subcomponent peid %s snapshot failed", components[0].GetID())
+		}
+	}
+
+	// If either the configmap info existed or the subsnapshot existed, then we successfully removed, otherwise
+	// there was no work (errors would have exited us already) so we return false
+	return subsnapshotExists || snapPVCInfoExists, nil
+}
+
+func (this PVCProtectedEntity) GetInfoForSnapshot(ctx context.Context, snapshotID astrolabe.ProtectedEntitySnapshotID) (*astrolabe.ProtectedEntityInfo, error) {
+	panic("implement me")
+}
+
+func (this PVCProtectedEntity) GetComponents(ctx context.Context) ([]astrolabe.ProtectedEntity, error) {
+	pvc, err := this.GetPVC()
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not retrieve PVC")
+	}
+
+	if pvc.Status.Phase != core_v1.ClaimBound {
+		this.logger.Infof("No bound PV for the PVC, %s. So, there is no component for the PVC PE, %s", pvc.Name, this.id.String())
+		return []astrolabe.ProtectedEntity{}, nil
+	}
+
+	pv, err := this.ppetm.clientSet.CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not retrieve Persistent Volume")
+	}
+
+	pvPE, err := this.getProtectedEntityForPV(ctx, pv)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not find subcomponent PEID for %s %s %s", this.id.String(), pvc.Namespace, pvc.Name)
+	}
+	return []astrolabe.ProtectedEntity{pvPE}, nil
+}
+
+func (this PVCProtectedEntity) getProtectedEntityForPV(ctx context.Context, pv *core_v1.PersistentVolume) (astrolabe.ProtectedEntity, error) {
+	if pv.Spec.CSI != nil {
+		if pv.Spec.CSI.Driver == VSphereCSIProvisioner {
+			if pv.Spec.AccessModes[0] == core_v1.ReadWriteOnce {
+				ivdPEID := astrolabe.NewProtectedEntityIDWithSnapshotID("ivd", pv.Spec.CSI.VolumeHandle, this.id.GetSnapshotID())
+				ivdPE, err := this.ppetm.pem.GetProtectedEntity(ctx, ivdPEID)
+				if err != nil {
+					return nil, errors.Wrapf(err, "Could not get Protected Entity for ivd %s", ivdPEID.String())
+				}
+				return ivdPE, nil
+			} else {
+				return nil, errors.Errorf("Unexpected access mode, %v, for Persistent Volume %s", pv.Spec.AccessModes[0], pv.Name)
+			}
+		}
+	}
+	return nil, errors.Errorf("Could not find PE for Persistent Volume %s", pv.Name)
+}
+func (this PVCProtectedEntity) GetID() astrolabe.ProtectedEntityID {
+	return this.id
+}
+
+func (this PVCProtectedEntity) GetDataReader(ctx context.Context) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (this PVCProtectedEntity) GetMetadataReader(ctx context.Context) (io.ReadCloser, error) {
+	if this.id.HasSnapshot() {
+		panic("Fix me - snapshot MD retrieval not implemented")
+	}
+	pvc, err := this.GetPVC()
+	if err != nil {
+		return nil, errors.Wrapf(err,"Could not get pvc")
+	}
+	pvcBytes, err := pvc.Marshal()
+	return ioutil.NopCloser(bytes.NewReader(pvcBytes)), nil
+}
+
+func (this PVCProtectedEntity) GetPVC() (*core_v1.PersistentVolumeClaim, error) {
+	namespace, name, err := GetNamespaceAndNameFromPEID(this.id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not get namespace and id from PEID %s", this.id.String())
+	}
+	pvc, err := this.ppetm.clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not get retrieve pvc with namespace %s, id %s", namespace, name)
+	}
+	return pvc, nil
+}

--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -1,0 +1,142 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/astrolabe/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"strings"
+)
+
+const (
+	pvcPEType = "pvc"
+	pvcPEIDSep = "/"
+)
+
+type PVCProtectedEntityTypeManager struct {
+	clientSet *kubernetes.Clientset
+	pem       astrolabe.ProtectedEntityManager
+	s3Config  astrolabe.S3Config
+	logger    logrus.FieldLogger
+}
+
+func NewProtectedEntityIDFromPVCName(namespace string, pvcName string) astrolabe.ProtectedEntityID {
+	idStr := namespace + pvcPEIDSep + pvcName
+	return astrolabe.NewProtectedEntityID(pvcPEType, idStr)
+}
+
+func GetNamespaceAndNameFromPEID(peid astrolabe.ProtectedEntityID) (namespace string, name string, err error) {
+	if peid.GetPeType() != pvcPEType {
+		return "", "", errors.New(fmt.Sprintf("%s + is not of type %s", peid.GetPeType(), pvcPEType))
+	}
+	parts := strings.Split(peid.GetID(), pvcPEIDSep)
+	if len(parts) != 2 {
+		return "", "", errors.New(fmt.Sprintf("%s has %d parts, expected 2", peid.GetID(), len(parts)))
+	}
+	return parts[0], parts[1], nil
+}
+
+func NewPVCProtectedEntityTypeManagerFromConfig(params map[string]interface{}, s3Config astrolabe.S3Config,
+	logger logrus.FieldLogger) (*PVCProtectedEntityTypeManager, error) {
+	masterURL, _ := util.GetStringFromParamsMap(params, "masterURL", logger)
+	kubeconfigPath, _ := util.GetStringFromParamsMap(params, "kubeconfigPath", logger)
+	config, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &PVCProtectedEntityTypeManager{
+		clientSet: clientSet,
+		s3Config: s3Config,
+		logger: logger,
+	}, nil
+}
+
+func (this *PVCProtectedEntityTypeManager) SetProtectedEntityManager(pem astrolabe.ProtectedEntityManager) {
+	this.pem = pem
+}
+
+func (this *PVCProtectedEntityTypeManager) GetTypeName() string {
+	return pvcPEType
+}
+
+func (this *PVCProtectedEntityTypeManager) GetProtectedEntity(ctx context.Context, peid astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntity, error) {
+	namespace, name, err := GetNamespaceAndNameFromPEID(peid)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not get namespace and name from peid %s", peid.String())
+	}
+
+	returnPE, err := newPVCProtectedEntity(this, peid)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not create PVCProtectedEntity for namespace = %s, name = %s", namespace, name)
+	}
+
+	_, err = returnPE.GetPVC()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not retrieve PVC for namespace = %s, name = %s", namespace, name)
+	}
+	return returnPE, nil
+}
+
+func (this *PVCProtectedEntityTypeManager) GetProtectedEntities(ctx context.Context) ([]astrolabe.ProtectedEntityID, error) {
+	nsList, err := this.clientSet.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not list namespaces")
+	}
+	retPEIDs := make([]astrolabe.ProtectedEntityID, 0)
+	for _, ns := range nsList.Items {
+		pvcList, err := this.clientSet.CoreV1().PersistentVolumeClaims(ns.Name).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not list PVCs")
+		}
+
+		for _, curPVC := range pvcList.Items {
+			retPEIDs = append(retPEIDs, NewProtectedEntityIDFromPVCName(curPVC.Namespace, curPVC.Name))
+		}
+	}
+	return retPEIDs, nil
+}
+
+func (this *PVCProtectedEntityTypeManager) Copy(ctx context.Context, pe astrolabe.ProtectedEntity, options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntity, error) {
+	panic("implement me")
+}
+
+func (this *PVCProtectedEntityTypeManager) CopyFromInfo(ctx context.Context, info astrolabe.ProtectedEntityInfo, options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntity, error) {
+	panic("implement me")
+}
+
+func (this *PVCProtectedEntityTypeManager) getDataTransports(id astrolabe.ProtectedEntityID) ([]astrolabe.DataTransport,
+	[]astrolabe.DataTransport,
+	[]astrolabe.DataTransport, error) {
+
+	data := []astrolabe.DataTransport{}
+
+	mdS3Transport, err := astrolabe.NewS3MDTransportForPEID(id, this.s3Config)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "Could not create S3 md transport")
+	}
+
+	md := []astrolabe.DataTransport{
+		mdS3Transport,
+	}
+
+	combinedS3Transport, err := astrolabe.NewS3CombinedTransportForPEID(id, this.s3Config)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "Could not create S3 combined transport")
+	}
+
+	combined := []astrolabe.DataTransport{
+		combinedS3Transport,
+	}
+
+	return data, md, combined, nil
+}

--- a/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
+++ b/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
@@ -1,0 +1,181 @@
+package tests
+
+import (
+	"context"
+	"github.com/magiconair/properties/assert"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
+	"github.com/vmware-tanzu/astrolabe/pkg/server"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetPVCComponents(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// path/to/whatever does not exist
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+
+	// get ivd params about VC credential
+	ivdParams := make(map[string]interface{})
+	if err = ivd.RetrievePlatformInfoFromConfig(config, ivdParams); err != nil {
+		t.Fatalf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	// get pvc params
+	pvcParams :=make(map[string]interface{})
+	pvcParams["kubeconfigPath"] = path
+
+	configParams := make(map[string]map[string]interface{})
+	configParams["pvc"] = pvcParams
+	configParams["ivd"] = ivdParams
+
+	configInfo := server.NewConfigInfo(configParams, astrolabe.S3Config{
+		URLBase:   "VOID_URL",
+	})
+
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+
+	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
+	if pvc_petm == nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	peids, err := pvc_petm.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, curPEID := range peids {
+		logger.Infof("curPEID = %v", curPEID.String())
+		curPE, err := pvc_petm.GetProtectedEntity(ctx, curPEID)
+		if err != nil {
+			logger.Errorf("Failed to get PVC PE with PEID = %v", curPEID.String())
+			t.Fatal(err)
+		}
+		componentPEs, err := curPE.GetComponents(ctx)
+		if err != nil {
+			logger.Errorf("Failed to get components for PVC PE with PEID = %v", curPEID.String())
+			t.Fatal(err)
+		}
+		for _, componentPE := range componentPEs {
+			logger.Infof("component PE ID = %v", componentPE.GetID().String())
+		}
+	}
+}
+
+func TestSnapshotOps(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// path/to/whatever does not exist
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+
+	// get ivd params about VC credential
+	ivdParams := make(map[string]interface{})
+	if err = ivd.RetrievePlatformInfoFromConfig(config, ivdParams); err != nil {
+		t.Fatalf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	// get pvc params
+	pvcParams :=make(map[string]interface{})
+	pvcParams["kubeconfigPath"] = path
+
+	configParams := make(map[string]map[string]interface{})
+	configParams["pvc"] = pvcParams
+	configParams["ivd"] = ivdParams
+
+	configInfo := server.NewConfigInfo(configParams, astrolabe.S3Config{
+		URLBase:   "VOID_URL",
+	})
+
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+
+	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
+	if pvc_petm == nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	peids, err := pvc_petm.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(peids) <= 0 {
+		t.Skip("No PVC can be found in the cluster")
+	}
+	selectedPEID := peids[0]
+	logger.Infof("Picked up the first available PVC PE, %v", selectedPEID.String())
+
+	pvcPE, err := pvc_petm.GetProtectedEntity(ctx, selectedPEID)
+	if err != nil {
+		logger.Errorf("Failed to get PVC PE with PEID = %v", selectedPEID.String())
+		t.Fatal(err)
+	}
+
+	peSnapshotIDs, err := pvcPE.ListSnapshots(ctx)
+	if err != nil {
+		logger.Errorf("Failed to list snapshots for the PVC PE with PEID = %v", pvcPE.GetID().String())
+		t.Fatal(err)
+	}
+
+	prevSnapshotsNum := len(peSnapshotIDs)
+	logger.Infof("There are %v snapshots for the PVC PE, %v, before snapshotting it", prevSnapshotsNum, pvcPE.GetID().String())
+
+	logger.Infof("Snapshotting the PVC PE, %v", selectedPEID.String())
+	peSnapshotID, err := pvcPE.Snapshot(ctx)
+	if err != nil {
+		logger.Errorf("Failed to snapshot PVC PE with PEID = %v", pvcPE.GetID().String())
+		t.Fatal(err)
+	}
+	logger.Infof("Snapshotted the PVC PE, %v with the snapshot ID as, %v", pvcPE.GetID().String(), peSnapshotID.String())
+
+	defer func() {
+		logger.Infof("Deleting snapshot, %v, for the PVC PE, %v", peSnapshotID.String(), pvcPE.GetID().String())
+		success, err := pvcPE.DeleteSnapshot(ctx, peSnapshotID)
+		if !success || err != nil {
+			logger.Errorf("Failed to delete snapshot, %v, for PVC PE with PEID = %v", peSnapshotID.String(), pvcPE.GetID().String())
+		}
+		logger.Infof("Deleted snapshot, %v, for the PVC PE, %v", peSnapshotID.String(), pvcPE.GetID().String())
+	}()
+
+	peSnapshotIDs, err = pvcPE.ListSnapshots(ctx)
+	if err != nil {
+		logger.Errorf("Failed to list snapshots for the PVC PE with PEID = %v", pvcPE.GetID().String())
+		t.Fatal(err)
+	}
+
+	curSnapshotsNum := len(peSnapshotIDs)
+	logger.Infof("There are %v snapshots for the PVC PE, %v, after snapshotting it", curSnapshotsNum, pvcPE.GetID().String())
+
+	assert.Equal(t, curSnapshotsNum - prevSnapshotsNum, 1, "there should be one more snapshot available")
+}
+

--- a/pkg/server/direct_protected_entity_manager.go
+++ b/pkg/server/direct_protected_entity_manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware-tanzu/astrolabe/pkg/fs"
 	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
 	"github.com/vmware-tanzu/astrolabe/pkg/kubernetes"
+	"github.com/vmware-tanzu/astrolabe/pkg/pvc"
 	"io/ioutil"
 	"log"
 	"os"
@@ -43,6 +44,10 @@ func NewDirectProtectedEntityManager(petms []astrolabe.ProtectedEntityTypeManage
 	}
 	for _, curPETM := range petms {
 		returnPEM.typeManager[curPETM.GetTypeName()] = curPETM
+		switch curPETM.(type) {
+		case *pvc.PVCProtectedEntityTypeManager:
+			curPETM.(*pvc.PVCProtectedEntityTypeManager).SetProtectedEntityManager(returnPEM)
+		}
 	}
 	returnPEM.s3Config = s3Config
 	return
@@ -53,13 +58,15 @@ func NewDirectProtectedEntityManagerFromConfigDir(confDirPath string) *DirectPro
 	if err != nil {
 		log.Fatalf("Could not read config files from dir %s, err: %v", confDirPath, err)
 	}
-	return NewDirectProtectedEntityManagerFromParamMap(configInfo)
+	return NewDirectProtectedEntityManagerFromParamMap(configInfo, nil)
 }
 
-func NewDirectProtectedEntityManagerFromParamMap(configInfo ConfigInfo) *DirectProtectedEntityManager {
+func NewDirectProtectedEntityManagerFromParamMap(configInfo ConfigInfo, logger logrus.FieldLogger) *DirectProtectedEntityManager {
 	petms := make([]astrolabe.ProtectedEntityTypeManager, 0) // No guarantee all configs will be valid, so don't preallocate
 	var err error
-	logger := logrus.New()
+	if logger == nil {
+		logger = logrus.New()
+	}
 	for serviceName, params := range configInfo.peConfigs {
 		var curService astrolabe.ProtectedEntityTypeManager
 		switch serviceName {
@@ -70,11 +77,13 @@ func NewDirectProtectedEntityManagerFromParamMap(configInfo ConfigInfo) *DirectP
 				logger)
 		case "fs":
 			curService, err = fs.NewFSProtectedEntityTypeManagerFromConfig(params, configInfo.s3Config, logger)
+		case "pvc":
+			curService, err = pvc.NewPVCProtectedEntityTypeManagerFromConfig(params, configInfo.s3Config, logger)
 		default:
-
+			logger.Warnf("Unknown service type, %v", serviceName)
 		}
 		if err != nil {
-			log.Printf("Could not start service %s err=%v", serviceName, err)
+			logger.Infof("Could not start service %s err=%v", serviceName, err)
 			continue
 		}
 		if curService != nil {
@@ -87,6 +96,13 @@ func NewDirectProtectedEntityManagerFromParamMap(configInfo ConfigInfo) *DirectP
 type ConfigInfo struct {
 	peConfigs map[string]map[string]interface{}
 	s3Config  astrolabe.S3Config
+}
+
+func NewConfigInfo(peConfigs map[string]map[string]interface{}, s3Config astrolabe.S3Config) ConfigInfo {
+	return ConfigInfo{
+		peConfigs: peConfigs,
+		s3Config:  s3Config,
+	}
 }
 
 func readConfigFiles(confDirPath string) (ConfigInfo, error) {
@@ -133,10 +149,7 @@ func readConfigFiles(confDirPath string) (ConfigInfo, error) {
 		log.Panicf("Could not read S3 configuration directory %s, err = %v\n", s3ConfFilePath, err)
 	}
 
-	return ConfigInfo{
-		peConfigs: configMap,
-		s3Config:  *s3Config,
-	}, nil
+	return NewConfigInfo(configMap, *s3Config), nil
 }
 
 func readConfigFile(confFile string) (map[string]interface{}, error) {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,17 @@
+package util
+
+import "github.com/sirupsen/logrus"
+
+func GetStringFromParamsMap(params map[string]interface{}, key string, logger logrus.FieldLogger) (value string, ok bool) {
+	valueIF, ok := params[key]
+	if ok {
+		value, ok := valueIF.(string)
+		if !ok {
+			logger.Errorf("Value for params key %s is not a string", key)
+		}
+		return value, ok
+	} else {
+		logger.Errorf("No such key %s in params map", key)
+		return "", ok
+	}
+}


### PR DESCRIPTION
Added a new PE type for PVC

Testing:
- Functional Test:
- - `KUBECONFIG=~/.kube/config go test -run TestGetPVCComponents -timeout 0 -v` - PASS
- - `KUBECONFIG=~/.kube/config go test -run TestSnapshotOps -timeout 0 -v` - PASS
- Regression Test:
- - https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/215/  (On-going)
