### PR TITLE
Added the support to register external PETM

### DIFF
--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -15,6 +15,7 @@ import (
 
 type PVCProtectedEntityTypeManager struct {
 	clientSet *kubernetes.Clientset
+	isGuest   bool
 	pem       astrolabe.ProtectedEntityManager
 	s3Config  astrolabe.S3Config
 	logger    logrus.FieldLogger
@@ -47,8 +48,10 @@ func NewPVCProtectedEntityTypeManagerFromConfig(params map[string]interface{}, s
 	if err != nil {
 		return nil, err
 	}
+	_, isGuest := params["svcNamespace"]
 	return &PVCProtectedEntityTypeManager{
 		clientSet: clientSet,
+		isGuest:   isGuest,
 		s3Config:  s3Config,
 		logger:    logger,
 	}, nil

--- a/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
+++ b/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
@@ -39,7 +39,7 @@ func TestGetPVCComponents(t *testing.T) {
 	}
 
 	// get pvc params
-	pvcParams :=make(map[string]interface{})
+	pvcParams := make(map[string]interface{})
 	pvcParams["kubeconfigPath"] = path
 
 	configParams := make(map[string]map[string]interface{})
@@ -47,7 +47,7 @@ func TestGetPVCComponents(t *testing.T) {
 	configParams["ivd"] = ivdParams
 
 	configInfo := server.NewConfigInfo(configParams, astrolabe.S3Config{
-		URLBase:   "VOID_URL",
+		URLBase: "VOID_URL",
 	})
 
 	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
@@ -106,7 +106,7 @@ func TestSnapshotOps(t *testing.T) {
 	}
 
 	// get pvc params
-	pvcParams :=make(map[string]interface{})
+	pvcParams := make(map[string]interface{})
 	pvcParams["kubeconfigPath"] = path
 
 	configParams := make(map[string]map[string]interface{})
@@ -114,14 +114,14 @@ func TestSnapshotOps(t *testing.T) {
 	configParams["ivd"] = ivdParams
 
 	configInfo := server.NewConfigInfo(configParams, astrolabe.S3Config{
-		URLBase:   "VOID_URL",
+		URLBase: "VOID_URL",
 	})
 
 	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
 
 	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
 	if pvc_petm == nil {
-		t.Fatal(err)
+		t.Fatal("Failed to get PVC ProtectedEntityTypeManager")
 	}
 
 	ctx := context.Background()
@@ -151,7 +151,7 @@ func TestSnapshotOps(t *testing.T) {
 	logger.Infof("There are %v snapshots for the PVC PE, %v, before snapshotting it", prevSnapshotsNum, pvcPE.GetID().String())
 
 	logger.Infof("Snapshotting the PVC PE, %v", selectedPEID.String())
-	peSnapshotID, err := pvcPE.Snapshot(ctx)
+	peSnapshotID, err := pvcPE.Snapshot(ctx, make(map[string]map[string]interface{}))
 	if err != nil {
 		logger.Errorf("Failed to snapshot PVC PE with PEID = %v", pvcPE.GetID().String())
 		t.Fatal(err)
@@ -176,6 +176,5 @@ func TestSnapshotOps(t *testing.T) {
 	curSnapshotsNum := len(peSnapshotIDs)
 	logger.Infof("There are %v snapshots for the PVC PE, %v, after snapshotting it", curSnapshotsNum, pvcPE.GetID().String())
 
-	assert.Equal(t, curSnapshotsNum - prevSnapshotsNum, 1, "there should be one more snapshot available")
+	assert.Equal(t, curSnapshotsNum-prevSnapshotsNum, 1, "there should be one more snapshot available")
 }
-

--- a/pkg/server/direct_protected_entity_manager.go
+++ b/pkg/server/direct_protected_entity_manager.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
@@ -36,11 +37,13 @@ import (
 type DirectProtectedEntityManager struct {
 	typeManager map[string]astrolabe.ProtectedEntityTypeManager
 	s3Config    astrolabe.S3Config
+	logger      logrus.FieldLogger
 }
 
-func NewDirectProtectedEntityManager(petms []astrolabe.ProtectedEntityTypeManager, s3Config astrolabe.S3Config) (returnPEM *DirectProtectedEntityManager) {
+func NewDirectProtectedEntityManager(petms []astrolabe.ProtectedEntityTypeManager, s3Config astrolabe.S3Config, logger logrus.FieldLogger) (returnPEM *DirectProtectedEntityManager) {
 	returnPEM = &DirectProtectedEntityManager{
 		typeManager: make(map[string]astrolabe.ProtectedEntityTypeManager),
+		logger:      logger,
 	}
 	for _, curPETM := range petms {
 		returnPEM.typeManager[curPETM.GetTypeName()] = curPETM
@@ -90,7 +93,7 @@ func NewDirectProtectedEntityManagerFromParamMap(configInfo ConfigInfo, logger l
 			petms = append(petms, curService)
 		}
 	}
-	return NewDirectProtectedEntityManager(petms, configInfo.S3Config)
+	return NewDirectProtectedEntityManager(petms, configInfo.S3Config, logger)
 }
 
 type ConfigInfo struct {
@@ -189,7 +192,13 @@ func readS3ConfigFile(s3ConfFile string) (*astrolabe.S3Config, error) {
 }
 
 func (this *DirectProtectedEntityManager) GetProtectedEntity(ctx context.Context, id astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntity, error) {
-	return this.typeManager[id.GetPeType()].GetProtectedEntity(ctx, id)
+	typeManager, ok := this.typeManager[id.GetPeType()]
+	if !ok {
+		errMsg := fmt.Sprintf("PeType, %v, is not available", id.GetPeType())
+		this.logger.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	return typeManager.GetProtectedEntity(ctx, id)
 }
 
 func (this *DirectProtectedEntityManager) GetProtectedEntityTypeManager(peType string) astrolabe.ProtectedEntityTypeManager {
@@ -202,4 +211,11 @@ func (this *DirectProtectedEntityManager) ListEntityTypeManagers() []astrolabe.P
 		returnArr = append(returnArr, curPETM)
 	}
 	return returnArr
+}
+
+func (this *DirectProtectedEntityManager) RegisterExternalProtectedEntityTypeManagers(petms []astrolabe.ProtectedEntityTypeManager) {
+	for _, curPETM := range petms {
+		this.logger.Infof("Registered External ProtectedEntityTypeManager: %v", curPETM.GetTypeName())
+		this.typeManager[curPETM.GetTypeName()] = curPETM
+	}
 }


### PR DESCRIPTION
1. Added the support to register external PETM
2. Adapted to select the right component PE between IVD and Paravirt from PVC PE

Signed-off-by: Lintong Jiang <lintongj@vmware.com>