### PR TITLE
Improved the retry workaround in IVD Snapshot API implemention

### DIFF
--- a/pkg/ivd/ivd_protected_entity_test.go
+++ b/pkg/ivd/ivd_protected_entity_test.go
@@ -49,12 +49,25 @@ func TestProtectedEntityIDFromString(t *testing.T) {
 
 }
 
+const (
+	MaxNumOfIVDs = 15
+)
+
 func TestSnapshotOpsUnderRaceCondition(t *testing.T) {
 	// #0: Setup the environment
 	// Prerequisite: export ASTROLABE_VC_URL='https://<VC USER>:<VC USER PASSWORD>@<VC IP>/sdk'
 	u, exist := os.LookupEnv("ASTROLABE_VC_URL")
 	if !exist {
 		t.Skipf("ASTROLABE_VC_URL is not set")
+	}
+
+	nIVDs := 5
+	nIVDsStr, ok := os.LookupEnv("NUM_OF_IVD")
+	if ok {
+		nIVDsInt, err := strconv.Atoi(nIVDsStr)
+		if err == nil && nIVDsInt > 0 && nIVDsInt <= MaxNumOfIVDs {
+			nIVDs = nIVDsInt
+		}
 	}
 
 	vcUrl, err := soap.ParseURL(u)
@@ -78,7 +91,6 @@ func TestSnapshotOpsUnderRaceCondition(t *testing.T) {
 	}
 
 	// #1: Create a few of IVDs
-	nIVDs := 5
 	datastoreType := types.HostFileSystemVolumeFileSystemTypeVsan
 	datastores, err := findAllAccessibleDatastoreByType(ctx, ivdPETM.client.Client, datastoreType)
 	if err != nil || len(datastores) <= 0 {


### PR DESCRIPTION
Improved the retry workaround in IVD Snapshot API implemention regarding the race between concurrent snapshot/deleteSnapshot API invocations

Testing:

Run IVD PE test case, TestSnapshotOpsUnderRaceCondition, for 100 times.
`NUM_OF_IVD=12 ASTROLABE_VC_URL='https://<vsphere user>:<vsphere password>@<vc ip>/sdk' go test ./pkg/ivd/... -run TestSnapshotOpsUnderRaceCondition -timeout 0 -v -failfast -count 100`
