### PR TITLE
Changes to pass go vet

### DIFF
--- a/cmd/astrolabe_server/main.go
+++ b/cmd/astrolabe_server/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"github.com/go-openapi/loads"
 	"github.com/vmware-tanzu/astrolabe/gen/restapi"
 	"github.com/vmware-tanzu/astrolabe/gen/restapi/operations"
@@ -42,7 +41,7 @@ func main() {
 	}
 	apiPort, err := strconv.Atoi(*apiPortStr)
 	if err != nil {
-		fmt.Errorf("apiPort %s is not an integer", *apiPortStr)
+		log.Printf("apiPort %s is not an integer\n", *apiPortStr)
 		os.Exit(1)
 	}
 	pem := server.NewProtectedEntityManager(*confDirStr)

--- a/pkg/client/client_protected_entity_manager.go
+++ b/pkg/client/client_protected_entity_manager.go
@@ -15,19 +15,19 @@ type ClientProtectedEntityManager struct {
 	typeManagerMutex sync.Mutex
 }
 
-func NewClientProtectedEntityManager(restClient *client.Astrolabe) (ClientProtectedEntityManager, error) {
+func NewClientProtectedEntityManager(restClient *client.Astrolabe) (*ClientProtectedEntityManager, error) {
 	returnClient := ClientProtectedEntityManager{
 		restClient:       restClient,
 		typeManagerMutex: sync.Mutex{},
 	}
 	err := returnClient.syncTypeManagers()
 	if err != nil {
-		return ClientProtectedEntityManager{}, err
+		return nil, err
 	}
-	return returnClient, nil
+	return &returnClient, nil
 }
 
-func (this ClientProtectedEntityManager) GetProtectedEntity(ctx context.Context, id astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntity, error) {
+func (this *ClientProtectedEntityManager) GetProtectedEntity(ctx context.Context, id astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntity, error) {
 	petm, ok := this.typeManagers[id.GetPeType()]
 	if !ok {
 		return nil, errors.New(fmt.Sprintf("could not find manager for type %s", id.GetPeType()))
@@ -35,7 +35,7 @@ func (this ClientProtectedEntityManager) GetProtectedEntity(ctx context.Context,
 	return petm.GetProtectedEntity(ctx, id)
 }
 
-func (this ClientProtectedEntityManager) GetProtectedEntityTypeManager(peType string) astrolabe.ProtectedEntityTypeManager {
+func (this *ClientProtectedEntityManager) GetProtectedEntityTypeManager(peType string) astrolabe.ProtectedEntityTypeManager {
 	petm, ok := this.typeManagers[peType]
 	if !ok {
 		return nil
@@ -43,7 +43,7 @@ func (this ClientProtectedEntityManager) GetProtectedEntityTypeManager(peType st
 	return petm
 }
 
-func (this ClientProtectedEntityManager) ListEntityTypeManagers() []astrolabe.ProtectedEntityTypeManager {
+func (this *ClientProtectedEntityManager) ListEntityTypeManagers() []astrolabe.ProtectedEntityTypeManager {
 	this.typeManagerMutex.Lock()
 	defer this.typeManagerMutex.Unlock()
 	returnPETMs := []astrolabe.ProtectedEntityTypeManager{}

--- a/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
+++ b/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
@@ -246,7 +246,8 @@ func TestCreateVolumeFromMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newPE, err := pvc_petm.(*astrolabe_pvc.PVCProtectedEntityTypeManager).CreateFromMetadata(ctx, pvcbytes, astrolabe.ProtectedEntityID{}, nil)
+	newPE, err := pvc_petm.(*astrolabe_pvc.PVCProtectedEntityTypeManager).CreateFromMetadata(ctx, pvcbytes, astrolabe.ProtectedEntityID{}, nil,
+		"", "")
 	if err != nil {
 		logger.Errorf("Failed to create volume from metadata: %s/%s", pvc.Name, pvc.Namespace)
 		t.Fatal(err)
@@ -351,7 +352,7 @@ func TestCreateVolumeFromMetadataAndS3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pvc_petm.(*astrolabe_pvc.PVCProtectedEntityTypeManager).CreateFromMetadata(ctx, pvcbytes, snapshotPEID, s3petm)
+	pvc_petm.(*astrolabe_pvc.PVCProtectedEntityTypeManager).CreateFromMetadata(ctx, pvcbytes, snapshotPEID, s3petm, "", "")
 }
 func setupS3PETM(t *testing.T, typeName string, logger *logrus.Logger) (*s3repository.ProtectedEntityTypeManager, error) {
 	sess, err := session.NewSession(&aws.Config{

--- a/pkg/s3repository/repository_protected_entity_type_manager_test.go
+++ b/pkg/s3repository/repository_protected_entity_type_manager_test.go
@@ -86,7 +86,7 @@ func TestCopyFSProtectedEntity(t *testing.T) {
 	fsParams := make(map[string]interface{})
 	fsParams["root"] = "/Users/dsmithuchida/astrolabe_fs_root"
 
-	fsPETM, err := fs.NewFSProtectedEntityTypeManagerFromConfig(fsParams, "notUsed", logrus.New())
+	fsPETM, err := fs.NewFSProtectedEntityTypeManagerFromConfig(fsParams, astrolabe.S3Config{}, logrus.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,12 +104,12 @@ func TestCopyFSProtectedEntity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		s3PE, err := s3petm.Copy(ctx, fsPE, astrolabe.AllocateNewObject)
+		s3PE, err := s3petm.Copy(ctx, fsPE, make(map[string]map[string]interface{}), astrolabe.AllocateNewObject)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		newFSPE, err := fsPETM.Copy(ctx, s3PE, astrolabe.AllocateNewObject)
+		newFSPE, err := fsPETM.Copy(ctx, s3PE, make(map[string]map[string]interface{}), astrolabe.AllocateNewObject)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +130,7 @@ func TestRetrieveEntity(t *testing.T) {
 	ivdParams[ivd.UserVcParamKey] = "administrator@vsphere.local"
 	ivdParams[ivd.PasswordVcParamKey] = "Admin!23"
 
-	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromConfig(ivdParams, "notUsed", logrus.New())
+	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromConfig(ivdParams, astrolabe.S3Config{}, logrus.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestRetrieveEntity(t *testing.T) {
 
 		fmt.Printf("%d bytes copied\n", bytesCopied)
 	*/
-	newIVDPE, err := ivdPETM.Copy(ctx, s3PE, astrolabe.AllocateNewObject)
+	newIVDPE, err := ivdPETM.Copy(ctx, s3PE, make(map[string]map[string]interface{}), astrolabe.AllocateNewObject)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestCopyIVDProtectedEntity(t *testing.T) {
 	ivdParams[ivd.UserVcParamKey] = "administrator@vsphere.local"
 	ivdParams[ivd.PasswordVcParamKey] = "Admin!23"
 
-	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromConfig(ivdParams, "notUsed", logrus.New())
+	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromConfig(ivdParams, astrolabe.S3Config{}, logrus.New())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestCopyIVDProtectedEntity(t *testing.T) {
 	if false {
 		ivdPE, err := ivdPETM.GetProtectedEntity(ctx, ivdPEID)
 
-		snapID, err = ivdPE.Snapshot(ctx)
+		snapID, err = ivdPE.Snapshot(ctx, make(map[string]map[string]interface{}))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,14 +239,14 @@ func TestCopyIVDProtectedEntity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		s3PE, err = s3petm.Copy(ctx, snapPE, astrolabe.AllocateNewObject)
+		s3PE, err = s3petm.Copy(ctx, snapPE, make(map[string]map[string]interface{}), astrolabe.AllocateNewObject)
 		if err != nil {
 			t.Fatal(err)
 		}
 	} else {
 		s3PE, err = s3petm.GetProtectedEntity(ctx, snapPEID)
 	}
-	newIVDPE, err := ivdPETM.Copy(ctx, s3PE, astrolabe.AllocateNewObject)
+	newIVDPE, err := ivdPETM.Copy(ctx, s3PE, make(map[string]map[string]interface{}), astrolabe.AllocateNewObject)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/openapi_handlers.go
+++ b/pkg/server/openapi_handlers.go
@@ -26,10 +26,10 @@ import (
 
 type OpenAPIAstrolabeHandler struct {
 	pem astrolabe.ProtectedEntityManager
-	tm  TaskManager
+	tm  *TaskManager
 }
 
-func NewOpenAPIAstrolabeHandler(pem astrolabe.ProtectedEntityManager, tm TaskManager) OpenAPIAstrolabeHandler {
+func NewOpenAPIAstrolabeHandler(pem astrolabe.ProtectedEntityManager, tm *TaskManager) OpenAPIAstrolabeHandler {
 	return OpenAPIAstrolabeHandler{
 		pem: pem,
 		tm:  tm,

--- a/pkg/server/task_manager.go
+++ b/pkg/server/task_manager.go
@@ -29,12 +29,12 @@ type TaskManager struct {
 	keepRunning bool
 }
 
-func NewTaskManager() TaskManager {
+func NewTaskManager() *TaskManager {
 	newTM := TaskManager{
 		keepRunning: true,
 	}
 	go newTM.cleanUpLoop()
-	return newTM
+	return &newTM
 }
 
 func (this *TaskManager) ListTasks() []astrolabe.TaskID {


### PR DESCRIPTION
Changed to use TaskManager and ClientProtectedEntityManager to use pointer in methods,
fixes copying of mutex
Fixed error message in astrolabe_server to actually output when apiPort not an integer
Fixed S3 repo test to use newer APIs, now compiles
Fixed params in pvc_protected_entity_type_manager_test, now compiles

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>