### PR TITLE
DiskConnectHandle.ReadAt was not handling reads at the end of the dis…

### DIFF
--- a/pkg/ivd/ivd_protected_entity_type_manager.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager.go
@@ -332,6 +332,9 @@ func (this *IVDProtectedEntityTypeManager) copyInt(ctx context.Context, sourcePE
 
 		this.logger.Debugf("Ready to provision a new volume with the source metadata: %v", md)
 		volumeVimID, err := CreateCnsVolumeInCluster(ctx, this.vcParams, this.client, this.cnsClient, md, this.logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "CreateDisk failed")
+		}
 		retPE, err = newIVDProtectedEntity(this, newProtectedEntityID(volumeVimID))
 		if err != nil {
 			return nil, errors.Wrap(err, "CreateDisk failed")

--- a/pkg/s3repository/repository_protected_entity.go
+++ b/pkg/s3repository/repository_protected_entity.go
@@ -385,7 +385,80 @@ func (this *ProtectedEntity) uploadSegment(ctx context.Context, baseName string,
 		// If the part has already been uploaded, we will skip
 		uploadPart := completedParts[partNumber] == nil
 		if uploadPart {
-			bytesRead, err := reader.Read(uploadBuffer)
+			bytesRead, err := io.ReadFull(reader, uploadBuffer)
+			if err != nil {
+				if err == io.EOF || err == io.ErrUnexpectedEOF {
+					moreBits = false
+				} else {
+					return bytesUploaded, err
+				}
+			}
+			if bytesRead > 0 {
+				thisPartNumber := partNumber + 1 // Copy because CompletedPart takes a pointer to the partNumber.
+				// AWS part numbers start at 1, so we offset here
+				uploadSlice := uploadBuffer[0:bytesRead]
+				bufferReader := bytes.NewReader(uploadSlice)
+				if partNumber == 0 && bytesRead < MinMultiPartSize {
+					// We don't have enough data to do a multipart upload
+					uploader := s3manager.NewUploader(&this.rpetm.session)
+
+					result, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+						Body:   bufferReader,
+						Bucket: awsBucketName,
+						Key:    awsKey,
+					})
+					if err == nil {
+						log.Infof("Successfully uploaded to", result.Location)
+					}
+					if err != nil {
+						return bytesUploaded, err
+					}
+					bytesUploaded += int64(bytesRead)
+					moreBits = false;
+				} else {
+					// Wait until here to start the multi-part upload in case we're too small
+					if uploadID == "" {
+						uploadInput := &s3.CreateMultipartUploadInput{
+							Bucket: awsBucketName,
+							Key:    awsKey,
+						}
+
+						resp, err := this.rpetm.s3.CreateMultipartUploadWithContext(ctx, uploadInput)
+						if err != nil {
+							return 0, err
+						}
+
+						uploadID = *resp.UploadId
+					}
+
+					partInput := &s3.UploadPartInput{
+						Body:          bufferReader,
+						Bucket:        awsBucketName,
+						Key:           awsKey,
+						PartNumber:    aws.Int64(thisPartNumber),
+						UploadId:      &uploadID,
+						ContentLength: aws.Int64(int64(bytesRead)),
+					}
+					partOutput, err := this.rpetm.s3.UploadPartWithContext(ctx, partInput)
+					if err != nil {
+						return bytesUploaded, err
+					}
+
+					log.Debug(partOutput)
+					bytesRead64 := int64(bytesRead)
+					completedPart := s3.Part{
+						ETag:       partOutput.ETag,
+						PartNumber: &thisPartNumber,
+						Size:       &bytesRead64,
+					}
+					completedParts[partNumber] = &completedPart
+				}
+				bytesUploaded += int64(bytesRead)
+			}
+		} else {
+			log.Infof("Skipping part %d, found pre-existing part", partNumber)
+			bytesToSkip := *completedParts[partNumber].Size
+			bytesSkipped, err := skipBytes(reader, bytesToSkip, uploadBuffer)
 			if err != nil {
 				if err == io.EOF {
 					moreBits = false
@@ -393,75 +466,8 @@ func (this *ProtectedEntity) uploadSegment(ctx context.Context, baseName string,
 					return bytesUploaded, err
 				}
 			}
-			thisPartNumber := partNumber + 1 // Copy because CompletedPart takes a pointer to the partNumber.
-			// AWS part numbers start at 1, so we offset here
-			uploadSlice := uploadBuffer[0:bytesRead]
-			bufferReader := bytes.NewReader(uploadSlice)
-			if partNumber == 0 && bytesRead < MinMultiPartSize {
-				// We don't have enough data to do a multipart upload
-				uploader := s3manager.NewUploader(&this.rpetm.session)
-
-				result, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
-					Body:   bufferReader,
-					Bucket: awsBucketName,
-					Key:    awsKey,
-				})
-				if err == nil {
-					log.Infof("Successfully uploaded to", result.Location)
-				}
-
-				if err != nil {
-					return bytesUploaded, err
-				}
-				bytesUploaded += int64(bytesRead)
-				moreBits = false
-			} else {
-				// Wait until here to start the multi-part upload in case we're too small
-				if uploadID == "" {
-					uploadInput := &s3.CreateMultipartUploadInput{
-						Bucket: awsBucketName,
-						Key:    awsKey,
-					}
-					resp, err := this.rpetm.s3.CreateMultipartUploadWithContext(ctx, uploadInput)
-					if err != nil {
-						return 0, err
-					}
-					uploadID = *resp.UploadId
-				}
-
-				partInput := &s3.UploadPartInput{
-					Body:          bufferReader,
-					Bucket:        awsBucketName,
-					Key:           awsKey,
-					PartNumber:    aws.Int64(thisPartNumber),
-					UploadId:      &uploadID,
-					ContentLength: aws.Int64(int64(bytesRead)),
-				}
-				partOutput, err := this.rpetm.s3.UploadPartWithContext(ctx, partInput)
-				if err != nil {
-					return bytesUploaded, err
-				}
-
-				log.Debug(partOutput)
-				bytesRead64 := int64(bytesRead)
-				completedPart := s3.Part{
-					ETag:       partOutput.ETag,
-					PartNumber: &thisPartNumber,
-					Size:       &bytesRead64,
-				}
-				completedParts[partNumber] = &completedPart
-			}
-			bytesUploaded += int64(bytesRead)
-		} else {
-			log.Infof("Skipping part %d, found pre-existing part", partNumber)
-			bytesSkipped, err := skipBytes(reader, *completedParts[partNumber].Size, uploadBuffer)
-			if err == io.EOF {
-				moreBits = false
-			} else {
-				return bytesUploaded, err
-			}
-			if bytesSkipped != bytesUploaded {
-				return bytesUploaded, errors.Errorf("Did not skip correct number of bytes bytesSkipped: %d expected:%d", bytesSkipped, *completedParts[partNumber].Size)
+			if bytesSkipped != bytesToSkip {
+				return bytesUploaded, errors.Errorf("Did not skip correct number of bytes bytesSkipped: %d expected:%d", bytesSkipped, bytesToSkip)
 			}
 			bytesUploaded += *completedParts[partNumber].Size
 

--- a/vendor/github.com/vmware/gvddk/gDiskLib/gvddk_api.go
+++ b/vendor/github.com/vmware/gvddk/gDiskLib/gvddk_api.go
@@ -236,19 +236,19 @@ func createDiskInfo(diskInfo *VixDiskLibInfo) (*C.VixDiskLibInfo, []*C.char) {
 	var dliInfo *C.VixDiskLibInfo
 	var bios C.VixDiskLibGeometry
 	var phys C.VixDiskLibGeometry
-	bios.cylinders = C.uint32(diskInfo.biosGeo.cylinders)
-	bios.heads = C.uint32(diskInfo.biosGeo.heads)
-	bios.sectors = C.uint32(diskInfo.biosGeo.sectors)
-	phys.cylinders = C.uint32(diskInfo.physGeo.cylinders)
-	phys.heads = C.uint32(diskInfo.physGeo.heads)
-	phys.sectors = C.uint32(diskInfo.physGeo.sectors)
+	bios.cylinders = C.uint32(diskInfo.BiosGeo.Cylinders)
+	bios.heads = C.uint32(diskInfo.BiosGeo.Heads)
+	bios.sectors = C.uint32(diskInfo.BiosGeo.Sectors)
+	phys.cylinders = C.uint32(diskInfo.PhysGeo.Cylinders)
+	phys.heads = C.uint32(diskInfo.PhysGeo.Heads)
+	phys.sectors = C.uint32(diskInfo.PhysGeo.Sectors)
 	dliInfo.biosGeo = bios
 	dliInfo.physGeo = phys
-	dliInfo.capacity = C.VixDiskLibSectorType(diskInfo.capacity)
-	dliInfo.adapterType = C.VixDiskLibAdapterType(diskInfo.adapterType)
-	dliInfo.numLinks = C.int(diskInfo.numLinks)
-	dliInfo.parentFileNameHint = C.CString(diskInfo.parentFileNameHint)
-	dliInfo.uuid = C.CString(diskInfo.uuid)
+	dliInfo.capacity = C.VixDiskLibSectorType(diskInfo.Capacity)
+	dliInfo.adapterType = C.VixDiskLibAdapterType(diskInfo.AdapterType)
+	dliInfo.numLinks = C.int(diskInfo.NumLinks)
+	dliInfo.parentFileNameHint = C.CString(diskInfo.ParentFileNameHint)
+	dliInfo.uuid = C.CString(diskInfo.Uuid)
 	var cParams = []*C.char{dliInfo.parentFileNameHint, dliInfo.uuid}
 	return dliInfo, cParams
 }
@@ -385,4 +385,32 @@ func Write(diskHandle VixDiskLibHandle, startSector uint64, numSectors uint64, b
 		return NewVddkError(uint64(res), fmt.Sprintf("Write to virtual disk file failed. The error code is %d.", res))
 	}
 	return nil
+}
+
+func GetInfo(diskHandle VixDiskLibHandle) (VixDiskLibInfo, VddkError) {
+	var dliInfoPtr *C.VixDiskLibInfo
+	res := C.VixDiskLib_GetInfo(diskHandle.dli, &dliInfoPtr)
+	if res != 0 {
+		return VixDiskLibInfo{}, NewVddkError(uint64(res), fmt.Sprintf("GetInfo failed. The error code is %d.", res))
+	}
+	dliInfo := *dliInfoPtr
+	retInfo := VixDiskLibInfo{
+		BiosGeo: VixDiskLibGeometry{
+			Cylinders: uint32(dliInfo.biosGeo.cylinders),
+			Heads: uint32(dliInfo.biosGeo.heads),
+			Sectors: uint32(dliInfo.biosGeo.sectors),
+		},
+		PhysGeo: VixDiskLibGeometry{
+			Cylinders: uint32(dliInfo.physGeo.cylinders),
+			Heads: uint32(dliInfo.physGeo.heads),
+			Sectors: uint32(dliInfo.physGeo.sectors),
+		},
+		Capacity: VixDiskLibSectorType(dliInfo.capacity),
+		AdapterType: VixDiskLibAdapterType(dliInfo.adapterType),
+		NumLinks: int(dliInfo.numLinks),
+		ParentFileNameHint: C.GoString(dliInfo.parentFileNameHint),
+		Uuid: C.GoString(dliInfo.uuid),
+	}
+	C.VixDiskLib_FreeInfo(dliInfoPtr)
+	return retInfo, nil
 }

--- a/vendor/github.com/vmware/gvddk/gDiskLib/gvddk_helper.go
+++ b/vendor/github.com/vmware/gvddk/gDiskLib/gvddk_helper.go
@@ -117,19 +117,19 @@ type VixDiskLibCreateParams struct {
 }
 
 type VixDiskLibGeometry struct {
-	cylinders uint32
-	heads uint32
-	sectors uint32
+	Cylinders uint32
+	Heads uint32
+	Sectors uint32
 }
 
 type VixDiskLibInfo struct {
-	biosGeo VixDiskLibGeometry
-	physGeo VixDiskLibGeometry
-	capacity VixDiskLibSectorType
-	adapterType VixDiskLibAdapterType
-	numLinks int
-	parentFileNameHint string
-	uuid string
+	BiosGeo            VixDiskLibGeometry
+	PhysGeo            VixDiskLibGeometry
+	Capacity           VixDiskLibSectorType
+	AdapterType        VixDiskLibAdapterType
+	NumLinks           int
+	ParentFileNameHint string
+	Uuid               string
 }
 
 func (this vddkErrorImpl) Error() string {

--- a/vendor/github.com/vmware/gvddk/gvddk-high/gvddk.go
+++ b/vendor/github.com/vmware/gvddk/gvddk-high/gvddk.go
@@ -42,23 +42,7 @@ func OpenFCD(serverName string, thumbPrint string, userName string, password str
 		flags,
 		readOnly,
 		transportMode)
-	err := gDiskLib.PrepareForAccess(globalParams)
-	if err != nil {
-		return DiskReaderWriter{}, err
-	}
-	conn, err := gDiskLib.ConnectEx(globalParams)
-	if err != nil {
-		gDiskLib.EndAccess(globalParams)
-		return DiskReaderWriter{}, err
-	}
-	dli, err := gDiskLib.Open(conn, globalParams)
-	if err != nil {
-		gDiskLib.Disconnect(conn)
-		gDiskLib.EndAccess(globalParams)
-		return DiskReaderWriter{}, err
-	}
-	diskHandle := NewDiskHandle(dli, conn, globalParams)
-	return NewDiskReaderWriter(diskHandle, logger), nil
+	return Open(globalParams, logger)
 }
 
 func Open(globalParams gDiskLib.ConnectParams, logger logrus.FieldLogger) (DiskReaderWriter, gDiskLib.VddkError) {
@@ -77,7 +61,13 @@ func Open(globalParams gDiskLib.ConnectParams, logger logrus.FieldLogger) (DiskR
 		gDiskLib.EndAccess(globalParams)
 		return DiskReaderWriter{}, err
 	}
-	diskHandle := NewDiskHandle(dli, conn, globalParams)
+	info, err := gDiskLib.GetInfo(dli)
+	if err != nil {
+		gDiskLib.Disconnect(conn)
+		gDiskLib.EndAccess(globalParams)
+		return DiskReaderWriter{}, err
+	}
+	diskHandle := NewDiskHandle(dli, conn, globalParams, info)
 	return NewDiskReaderWriter(diskHandle, logger), nil
 }
 
@@ -157,15 +147,18 @@ type DiskConnectHandle struct {
 	dli    gDiskLib.VixDiskLibHandle
 	conn   gDiskLib.VixDiskLibConnection
 	params gDiskLib.ConnectParams
+	info   gDiskLib.VixDiskLibInfo
 }
 
-func NewDiskHandle(dli gDiskLib.VixDiskLibHandle, conn gDiskLib.VixDiskLibConnection, params gDiskLib.ConnectParams) DiskConnectHandle {
+func NewDiskHandle(dli gDiskLib.VixDiskLibHandle, conn gDiskLib.VixDiskLibConnection, params gDiskLib.ConnectParams,
+	info gDiskLib.VixDiskLibInfo) DiskConnectHandle {
 	var mutex sync.Mutex
 	return DiskConnectHandle{
 		mutex:  &mutex,
 		dli:    dli,
 		conn:   conn,
 		params: params,
+		info: info,
 	}
 }
 
@@ -183,6 +176,15 @@ func aligned(len int, off int64) bool {
 }
 
 func (this DiskConnectHandle) ReadAt(p []byte, off int64) (n int, err error) {
+	capacity := this.Capacity()
+	if off >= capacity {
+		return 0, io.EOF
+	}
+	// If we're being asked for a read beyond the end of the disk, slice the buffer down
+	if off + int64(len(p)) > capacity {
+		readLen := int32(capacity - off)
+		p = p[0:readLen]
+	}
 	startSector := off / gDiskLib.VIXDISKLIB_SECTOR_SIZE
 	var total int = 0
 
@@ -238,6 +240,12 @@ func (this DiskConnectHandle) ReadAt(p []byte, off int64) (n int, err error) {
 }
 
 func (this DiskConnectHandle) WriteAt(p []byte, off int64) (n int, err error) {
+	capacity := this.Capacity()
+	// Just error if either the beginning or the end of the write extends beyond the end
+	if off > capacity || off + int64(len(p)) > capacity{
+		return 0, io.ErrShortWrite
+	}
+
 	if (!aligned(len(p), off)) {
 		// Lock versus read and write of misaligned data so that read/modify/write cycle always gives correct
 		// behavior (read/write is atomic even though misaligned)
@@ -318,4 +326,8 @@ func (this DiskConnectHandle) Close() error {
 	}
 
 	return nil
+}
+
+func (this DiskConnectHandle) Capacity() int64 {
+	return int64(this.info.Capacity) * gDiskLib.VIXDISKLIB_SECTOR_SIZE
 }


### PR DESCRIPTION
…k properly.  If the blocks being read

extended beyond the end of the disk, an EOF would be returned with 0 bytes being read.  This would cause
uploads of the data to abort prematurely and lose data.  Modified DiskConnectHandle.ReadAt to check the actual
size of the disk/snapshot being read and adjust the size of the buffer so that the available blocks are read and
returned.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>