### PR TITLE
Catch connection reset by peer network issue in DeleteSnapshot and CreateSnapshot

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,6 +1,9 @@
 package util
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+	"strings"
+)
 
 func GetStringFromParamsMap(params map[string]interface{}, key string, logger logrus.FieldLogger) (value string, ok bool) {
 	valueIF, ok := params[key]
@@ -14,4 +17,11 @@ func GetStringFromParamsMap(params map[string]interface{}, key string, logger lo
 		logger.Errorf("No such key %s in params map", key)
 		return "", ok
 	}
+}
+
+func IsConnectionResetError(err error) bool {
+	if strings.Contains(err.Error(), "connection reset by peer") {
+		return true
+	}
+	return false
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+    "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckConnectionResetError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Connection reset by peer error should return true",
+			err:      errors.New("read tcp 10.244.2.4:38316->10.208.22.141:443: read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "Other error should return false",
+			err:      errors.New("This is not a connection reset error"),
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isConnectionError := IsConnectionResetError(test.err)
+			assert.Equal(t, test.expected, isConnectionError)
+		})
+	}
+}


### PR DESCRIPTION
A simple change to update DeleteSnapshot and CreateSnapshot APIs to retry on "connection reset by peer" network issue. Add unit test to check string comparison.

Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/524/

Relevant bug link:
https://bugzilla.eng.vmware.com/show_bug.cgi?id=2614753
https://bugzilla.eng.vmware.com/show_bug.cgi?id=2634621