### PR TITLE
Changed from context.TODO to context.Background in CLI.

### DIFF
--- a/cmd/astrolabe/main.go
+++ b/cmd/astrolabe/main.go
@@ -132,7 +132,7 @@ func ls(c *cli.Context) error {
 	if petm == nil {
 		log.Fatalf("Could not find type named %s", peType)
 	}
-	peIDs, err := petm.GetProtectedEntities(context.TODO())
+	peIDs, err := petm.GetProtectedEntities(context.Background())
 	if err != nil {
 		log.Fatalf("Could not retrieve protected entities for type %s err:%b", peType, err)
 	}
@@ -155,12 +155,12 @@ func lssn(c *cli.Context) error {
 		log.Fatalf("Could not setup protected entity manager, err =%v", err)
 	}
 
-	pe, err := pem.GetProtectedEntity(context.TODO(), peID)
+	pe, err := pem.GetProtectedEntity(context.Background(), peID)
 	if err != nil {
 		log.Fatalf("Could not retrieve protected entity ID %s, err: %v", peIDStr, err)
 	}
 
-	snaps, err := pe.ListSnapshots(context.TODO())
+	snaps, err := pe.ListSnapshots(context.Background())
 	if err != nil {
 		log.Fatalf("Could not get snapshots for protected entity ID %s, err: %v", peIDStr, err)
 	}
@@ -184,12 +184,12 @@ func show(c *cli.Context) error {
 		log.Fatalf("Could not setup protected entity manager, err =%v", err)
 	}
 
-	pe, err := pem.GetProtectedEntity(context.TODO(), peID)
+	pe, err := pem.GetProtectedEntity(context.Background(), peID)
 	if err != nil {
 		log.Fatalf("Could not retrieve protected entity ID %s, err: %v", peIDStr, err)
 	}
 
-	info, err := pe.GetInfo(context.TODO())
+	info, err := pe.GetInfo(context.Background())
 	if err != nil {
 		log.Fatalf("Could not retrieve info for %s, err: %v", peIDStr, err)
 	}
@@ -209,11 +209,11 @@ func snap(c *cli.Context) error {
 		log.Fatalf("Could not setup protected entity manager, err =%v", err)
 	}
 
-	pe, err := pem.GetProtectedEntity(context.TODO(), peID)
+	pe, err := pem.GetProtectedEntity(context.Background(), peID)
 	if err != nil {
 		log.Fatalf("Could not retrieve protected entity ID %s, err: %v", peIDStr, err)
 	}
-	snap, err := pe.Snapshot(context.TODO(), make(map[string]map[string]interface{}))
+	snap, err := pe.Snapshot(context.Background(), make(map[string]map[string]interface{}))
 	if err != nil {
 		log.Fatalf("Could not snapshot protected entity ID %s, err: %v", peIDStr, err)
 	}
@@ -236,11 +236,11 @@ func rmsn(c *cli.Context) error {
 		log.Fatalf("Could not setup protected entity manager, err =%v", err)
 	}
 
-	pe, err := pem.GetProtectedEntity(context.TODO(), peID)
+	pe, err := pem.GetProtectedEntity(context.Background(), peID)
 	if err != nil {
 		log.Fatalf("Could not retrieve protected entity ID %s, err: %v", peIDStr, err)
 	}
-	success, err := pe.DeleteSnapshot(context.TODO(), peID.GetSnapshotID(), make(map[string]map[string]interface{}))
+	success, err := pe.DeleteSnapshot(context.Background(), peID.GetSnapshotID(), make(map[string]map[string]interface{}))
 	if err != nil {
 		log.Fatalf("Could not remove snapshot ID %s, err: %v", peIDStr, err)
 	}
@@ -279,13 +279,13 @@ func cp(c *cli.Context) error {
 		fmt.Printf("file %s", srcFile)
 	} else {
 		fmt.Printf("pe %s", srcPEID.String())
-		srcPE, err := pem.GetProtectedEntity(context.TODO(), srcPEID)
+		srcPE, err := pem.GetProtectedEntity(context.Background(), srcPEID)
 		if err != nil {
 			log.Fatalf("Could not retrieve protected entity ID %s, err: %v", srcPEID.String(), err)
 		}
 		var dw io.WriteCloser
 		reader, dw = io.Pipe()
-		go zipPE(context.TODO(), srcPE, dw)
+		go zipPE(context.Background(), srcPE, dw)
 	}
 	fmt.Printf(" to ")
 	if destFile != "" {

--- a/gen/restapi/server.go
+++ b/gen/restapi/server.go
@@ -417,7 +417,7 @@ func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) 
 
 	servers := *serversPtr
 
-	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), s.GracefulTimeout)
 	defer cancel()
 
 	// first execute the pre-shutdown hook

--- a/pkg/kubernetes/kubernetes_namespace_protected_entity_type_manager.go
+++ b/pkg/kubernetes/kubernetes_namespace_protected_entity_type_manager.go
@@ -51,7 +51,7 @@ func NewKubernetesNamespaceProtectedEntityTypeManagerFromConfig(params map[strin
 		s3Config:  s3Config,
 	}
 	returnTypeManager.namespaces = make(map[string]*KubernetesNamespaceProtectedEntity)
-	err = returnTypeManager.loadNamespaceEntities()
+	err = returnTypeManager.loadNamespaceEntities(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +77,8 @@ func (this *KubernetesNamespaceProtectedEntityTypeManager) GetProtectedEntities(
 	return protectedEntities, nil
 }
 
-func (this *KubernetesNamespaceProtectedEntityTypeManager) loadNamespaceEntities() error {
-	namespaceList, err := this.clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+func (this *KubernetesNamespaceProtectedEntityTypeManager) loadNamespaceEntities(ctx context.Context) error {
+	namespaceList, err := this.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -81,7 +81,7 @@ func (this *PVCProtectedEntityTypeManager) GetProtectedEntity(ctx context.Contex
 		return nil, errors.Wrapf(err, "Could not create PVCProtectedEntity for namespace = %s, name = %s", namespace, name)
 	}
 
-	_, err = returnPE.GetPVC()
+	_, err = returnPE.GetPVC(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not retrieve PVC for namespace = %s, name = %s", namespace, name)
 	}
@@ -173,7 +173,7 @@ func (this *PVCProtectedEntityTypeManager) CreateFromMetadata(ctx context.Contex
 	if dynamic {
 
 		// Creates a new PVC (dynamic provisioning path)
-		if _, err = this.clientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), &pvc, metav1.CreateOptions{}); err == nil || apierrs.IsAlreadyExists(err) {
+		if _, err = this.clientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, &pvc, metav1.CreateOptions{}); err == nil || apierrs.IsAlreadyExists(err) {
 			// Save succeeded.
 			if err != nil {
 				this.logger.Infof("PVC %s/%s already exists, reusing", pvc.Namespace, pvc.Name)
@@ -187,7 +187,7 @@ func (this *PVCProtectedEntityTypeManager) CreateFromMetadata(ctx context.Contex
 		}
 		this.logger.Infof("CreateFromMetadata: created PVC: %s/%s", pvc.Namespace, pvc.Name)
 
-		err = WaitForPersistentVolumeClaimPhase(v1.ClaimBound, this.clientSet, pvc.Namespace, pvc.Name, Poll, ClaimBindingTimeout, this.logger)
+		err = WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, this.clientSet, pvc.Namespace, pvc.Name, Poll, ClaimBindingTimeout, this.logger)
 		if err != nil {
 			return nil, fmt.Errorf("PVC %q did not become Bound: %v", pvc.Name, err)
 		}

--- a/pkg/pvc/utils.go
+++ b/pkg/pvc/utils.go
@@ -20,13 +20,13 @@ const (
 )
 
 // WaitForPersistentVolumeClaimPhase waits for a PersistentVolumeClaim to be in a specific phase or until timeout occurs, whichever comes first.
-func WaitForPersistentVolumeClaimPhase(phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcName string, Poll, timeout time.Duration, logger logrus.FieldLogger) error {
-	return WaitForPersistentVolumeClaimsPhase(phase, c, ns, []string{pvcName}, Poll, timeout, true, logger)
+func WaitForPersistentVolumeClaimPhase(ctx context.Context, phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcName string, Poll, timeout time.Duration, logger logrus.FieldLogger) error {
+	return WaitForPersistentVolumeClaimsPhase(ctx, phase, c, ns, []string{pvcName}, Poll, timeout, true, logger)
 }
 
 // WaitForPersistentVolumeClaimsPhase waits for any (if matchAny is true) or all (if matchAny is false) PersistentVolumeClaims
 // to be in a specific phase or until timeout occurs, whichever comes first.
-func WaitForPersistentVolumeClaimsPhase(phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcNames []string, Poll, timeout time.Duration, matchAny bool, logger logrus.FieldLogger) error {
+func WaitForPersistentVolumeClaimsPhase(ctx context.Context, phase v1.PersistentVolumeClaimPhase, c clientset.Interface, ns string, pvcNames []string, Poll, timeout time.Duration, matchAny bool, logger logrus.FieldLogger) error {
 	if len(pvcNames) == 0 {
 		return fmt.Errorf("incorrect parameter: Need at least one PVC to track. Found 0")
 	}
@@ -34,7 +34,7 @@ func WaitForPersistentVolumeClaimsPhase(phase v1.PersistentVolumeClaimPhase, c c
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(Poll) {
 		phaseFoundInAllClaims := true
 		for _, pvcName := range pvcNames {
-			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil {
 				logger.Errorf("Failed to get claim %q, retrying in %v. Error: %v", pvcName, Poll, err)
 				continue


### PR DESCRIPTION
Calls from the CLI will not have a context for cancellation

Removed context.TODO(), added context to function arguments where needed

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>