### PR TITLE
Pass api error to IVD PE

### DIFF
--- a/pkg/common/vsphere/cns_manager.go
+++ b/pkg/common/vsphere/cns_manager.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -99,7 +98,7 @@ func (this *CnsManager) processError(invokeCount int, apiError error) (*cns.Clie
 		log.Infof("Successfully re-initiated vcenter connection")
 	} else {
 		// Return the error on actual api error conditions.
-		return nil, errors.Wrapf(apiError, "Error received on api invocation")
+		return nil, apiError
 	}
 	return refreshedCnsClient, nil
 }

--- a/pkg/common/vsphere/vslm_manager.go
+++ b/pkg/common/vsphere/vslm_manager.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	vim "github.com/vmware/govmomi/vim25/types"
 	vslm_vsom "github.com/vmware/govmomi/vslm"
@@ -265,7 +264,7 @@ func (this *VslmManager) processError(invokeCount int, apiError error) (*vslm_vs
 		log.Infof("Successfully re-initiated vcenter connection")
 	} else {
 		// Return the error on actual api error conditions.
-		return nil, errors.Wrapf(apiError, "Error received on api invocation")
+		return nil, apiError
 	}
 	return refreshedVsom, nil
 }


### PR DESCRIPTION
1. The errors are inspected in the upper layer to determine if it needs to be retried.
2. Wrapping the error loses the error type.
3. Prevent retry on RetrieveSanpshotDetails failure on non IvalidArg faults.
4. Additional logging.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>