### PR TITLE
WIP: Fixed github action script due to deprecated command, set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
           wget --quiet https://gvddk-libs.s3-us-west-1.amazonaws.com/VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
           tar xzf VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
           chmod 644 $(find vmware-vix-disklib-distrib/lib64/ -type f)
-      - name: Set env
-        run: echo "::set-env name=GOPATH::$GITHUB_WORKSPACE"
       - name: Make CI
         run: |
           cd src/github.com/vmware-tanzu/astrolabe


### PR DESCRIPTION
Fixed github action script due to deprecated command, set-env

Signed-off-by: Lintong Jiang <lintongj@vmware.com>