### PR TITLE
[Cherry-pick]DeleteSnapshot fixes (#62)

### DIFF
--- a/pkg/astrolabe/constants.go
+++ b/pkg/astrolabe/constants.go
@@ -1,5 +1,7 @@
 package astrolabe
 
 const (
-	PvcPEType = "pvc"
+	PvcPEType        = "pvc"
+	ParaVirtPvPEType = "paravirt-pv"
+	IvdPEType        = "ivd"
 )

--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -81,10 +81,6 @@ func (this *PVCProtectedEntityTypeManager) GetProtectedEntity(ctx context.Contex
 		return nil, errors.Wrapf(err, "Could not create PVCProtectedEntity for namespace = %s, name = %s", namespace, name)
 	}
 
-	_, err = returnPE.GetPVC(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Could not retrieve PVC for namespace = %s, name = %s", namespace, name)
-	}
 	return returnPE, nil
 }
 


### PR DESCRIPTION
1. If Pandora does not find the FCD in its in-memory cache delete snapshot immediately returns a NotFound error. The current change checks if a NotFound error is returned, if so it assumes the DeleteSnapshot as a success.
2. Triggering GetComponents on a PVC PE queries the k8s API server for the pvc, this causes an issue when we are deleting backup on a fresh setup connected to a bucket that contains older backups. The change removes any call to k8s API server in the DeleteSnapshot Path.
3. Removed called to GetPVC in pvc petm as it's not used, code paths that require PVC info call the GetPVC method explicitly.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>