### PR TITLE
Disconnected vCenter reconciliation

### DIFF
--- a/changelogs/unreleased/0076-dkinni
+++ b/changelogs/unreleased/0076-dkinni
@@ -1,0 +1,1 @@
+Disconnected vCenter reconciliation, handle cases when unable to connect to vc during startup.


### PR DESCRIPTION
During the data-manager and backupdriver startup, an attempt is made to initialize ivd petm.
Before the fix, the ivd petm would not be registered if there were errors while establishing a vCenter connection.
Even if the vc comes back online, there was no mechanism to re-register ivd petm.
With this fix, the ivd petm is registered even if there were errors while initializing ivd petm.
Furthermore, the vcenter connections are checked before any vCenter operation, and connections are re-established if no present.

Confluence:
https://confluence.eng.vmware.com/display/~dkinni/Disconnected+VC+Connection+Reconciliation+Velero+vSphere+Plugin

Testing
Please refer https://confluence.eng.vmware.com/display/~dkinni/Disconnected+VC+Connection+Reconciliation+Velero+vSphere+Plugin for all the testing done.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>