### PR TITLE
Fixed a bug in the s3repository

### DIFF
--- a/changelogs/unreleased/079-dsmithuchida
+++ b/changelogs/unreleased/079-dsmithuchida
@@ -1,0 +1,6 @@
+Fixed a bug in the s3repository 
+RepositoryProtectedEntityTypeManager.GetProtectedEntitiesByIDPrefix that was
+not handling pagination in results properly.  This call would loop if there were
+more than 1000 results matching the prefix.  Fixed to use the NextContinuationToken
+instead of ContinuationToken for the where to start the next loop
+

--- a/pkg/s3repository/repository_protected_entity_type_manager.go
+++ b/pkg/s3repository/repository_protected_entity_type_manager.go
@@ -219,7 +219,7 @@ func (this *ProtectedEntityTypeManager) GetProtectedEntitiesByIDPrefix(ctx conte
 		if !*results.IsTruncated {
 			hasMore = false
 		} else {
-			continuationToken = results.ContinuationToken
+			continuationToken = results.NextContinuationToken
 		}
 	}
 	return retPEIDs, nil
@@ -259,8 +259,7 @@ func (this *ProtectedEntityTypeManager) Copy(ctx context.Context, sourcePE astro
 
 func (this *ProtectedEntityTypeManager) CopyFromInfo(ctx context.Context, sourcePEInfo astrolabe.ProtectedEntityInfo, params map[string]map[string]interface{},
 	options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntity, error) {
-
-	return nil, nil
+		return this.copyInt(ctx, sourcePEInfo, options, nil, nil)
 }
 
 func (this *ProtectedEntityTypeManager) copyInt(ctx context.Context, sourcePEInfo astrolabe.ProtectedEntityInfo,
@@ -305,7 +304,7 @@ func (this *ProtectedEntityTypeManager) copyInt(ctx context.Context, sourcePEInf
 	combinedTransports := []astrolabe.DataTransport{}
 
 	rPEInfo := astrolabe.NewProtectedEntityInfo(sourcePEInfo.GetID(), sourcePEInfo.GetName(),
-		sourcePEInfo.GetSize(), dataTransports, metadataTransports, combinedTransports,
+		sourcePEInfo.GetSize(),	dataTransports, metadataTransports, combinedTransports,
 		sourcePEInfo.GetComponentIDs())
 
 	rpe := ProtectedEntity{
@@ -341,7 +340,6 @@ func (this *ProtectedEntityTypeManager) getDataTransports(id astrolabe.Protected
 	data := []astrolabe.DataTransport{
 		astrolabe.NewDataTransportForS3URL(dataS3URL),
 	}
-
 	mdS3URL := dataS3URL + ".md"
 
 	md := []astrolabe.DataTransport{
@@ -354,4 +352,38 @@ func (this *ProtectedEntityTypeManager) getDataTransports(id astrolabe.Protected
 	}
 
 	return data, md, combined, nil
+}
+
+func (this *ProtectedEntityTypeManager) Delete(ctx context.Context, id astrolabe.ProtectedEntityID) error {
+	if id.GetPeType() != this.typeName {
+		return errors.New(id.GetPeType() + " is not of type " + this.typeName)
+	}
+
+	peToDelete, err := this.GetProtectedEntity(ctx, id)
+	if err != nil {
+		return err
+	}
+	peInfoName := this.peinfoName(peToDelete.GetID())
+	deleteObjects := []*s3.ObjectIdentifier{
+		&s3.ObjectIdentifier{
+			Key:       aws.String(peInfoName),
+		},
+	}
+	deleteObjectsInput := s3.DeleteObjectsInput{
+		Bucket:                    aws.String(this.bucket),
+		Delete:                    & s3.Delete{
+			Objects: deleteObjects,
+		},
+		MFA:                       nil,
+		RequestPayer:              nil,
+	}
+
+	deleteObjectsOutput, err := this.s3.DeleteObjects(&deleteObjectsInput)
+	if err != nil {
+		return err
+	}
+	if len(deleteObjectsOutput.Errors) > 0 {
+		return errors.New("Could not delete all S3 objects")
+	}
+	return nil
 }


### PR DESCRIPTION
RepositoryProtectedEntityTypeManager.GetProtectedEntitiesByIDPrefix that was
not handling pagination in results properly.  This call would loop if there were
more than 1000 results matching the prefix.  Fixed to use the NextContinuationToken
instead of ContinuationToken for the where to start the next loop

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>