### PR TITLE
Change to use 7.0.2 vddk libs from 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Download essential GVDDK libraries
         run: |
           cd /tmp
-          wget --quiet https://gvddk-libs.s3-us-west-1.amazonaws.com/VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
+          wget --quiet https://gvddk-libs.s3-us-west-1.amazonaws.com/VMware-vix-disklib-7.0.2-17696664.x86_64.tar.gz
           cd /usr/local
-          sudo tar xzf /tmp/VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
+          sudo tar xzf /tmp/VMware-vix-disklib-7.0.2-17696664.x86_64.tar.gz
           sudo chmod 644 $(find vmware-vix-disklib-distrib/lib64/ -type f)
       - name: Make CI
         env:


### PR DESCRIPTION
Change VDDK libs from 7.0 to 7.0.2

Tested with basic backup/restore operation.
Precheck test passed: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/1055/ 