### PR TITLE
Added addonInits to ProtectedEntityManager

### DIFF
--- a/cmd/astrolabe/main.go
+++ b/cmd/astrolabe/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -98,7 +99,7 @@ func main() {
 func setupProtectedEntityManager(c *cli.Context) (pem astrolabe.ProtectedEntityManager, err error) {
 	confDirStr := c.String("confDir")
 	if confDirStr != "" {
-		pem = server.NewProtectedEntityManager(confDirStr)
+		pem = server.NewProtectedEntityManager(confDirStr, nil, logrus.StandardLogger())
 		return
 	}
 	host := c.String("host")

--- a/cmd/astrolabe_server/main.go
+++ b/cmd/astrolabe_server/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"github.com/go-openapi/loads"
+	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/gen/restapi"
 	"github.com/vmware-tanzu/astrolabe/gen/restapi/operations"
 	"github.com/vmware-tanzu/astrolabe/pkg/server"
@@ -44,7 +45,7 @@ func main() {
 		log.Printf("apiPort %s is not an integer\n", *apiPortStr)
 		os.Exit(1)
 	}
-	pem := server.NewProtectedEntityManager(*confDirStr)
+	pem := server.NewProtectedEntityManager(*confDirStr, nil, logrus.StandardLogger())
 	tm := server.NewTaskManager()
 	apiHandler := server.NewOpenAPIAstrolabeHandler(pem, tm)
 	// load embedded swagger file

--- a/pkg/fs/fs_protected_entity_type_manager.go
+++ b/pkg/fs/fs_protected_entity_type_manager.go
@@ -36,7 +36,7 @@ type FSProtectedEntityTypeManager struct {
 const kTYPE_NAME = "fs"
 
 func NewFSProtectedEntityTypeManagerFromConfig(params map[string]interface{}, s3Config astrolabe.S3Config,
-	logger logrus.FieldLogger) (*FSProtectedEntityTypeManager, error) {
+	logger logrus.FieldLogger) (astrolabe.ProtectedEntityTypeManager, error) {
 	root := params["root"].(string)
 
 	returnTypeManager := FSProtectedEntityTypeManager{

--- a/pkg/ivd/ivd_protected_entity_type_manager.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager.go
@@ -51,7 +51,7 @@ type IVDProtectedEntityTypeManager struct {
 
 func NewIVDProtectedEntityTypeManager(params map[string]interface{},
 	s3Config astrolabe.S3Config,
-	logger logrus.FieldLogger) (*IVDProtectedEntityTypeManager, error) {
+	logger logrus.FieldLogger) (astrolabe.ProtectedEntityTypeManager, error) {
 	logger.Infof("Initializing IVD Protected Entity Manager")
 	retVal := IVDProtectedEntityTypeManager{
 		s3Config:      s3Config,

--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -36,7 +36,7 @@ restConfig - *rest.Config - if set, this will be used
 if restConfig is not set, masterURL and kubeConfigPath will be used.  Either can be set
 */
 func NewPVCProtectedEntityTypeManagerFromConfig(params map[string]interface{}, s3Config astrolabe.S3Config,
-	logger logrus.FieldLogger) (*PVCProtectedEntityTypeManager, error) {
+	logger logrus.FieldLogger) (astrolabe.ProtectedEntityTypeManager, error) {
 	var err error
 	var config *rest.Config
 	config, ok := params["restConfig"].(*rest.Config)

--- a/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
+++ b/pkg/pvc/tests/pvc_protected_entity_type_manager_test.go
@@ -55,7 +55,7 @@ func TestGetPVCComponents(t *testing.T) {
 		URLBase: "VOID_URL",
 	})
 
-	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, nil, logger)
 
 	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
 	if pvc_petm == nil {
@@ -122,7 +122,7 @@ func TestSnapshotOps(t *testing.T) {
 		URLBase: "VOID_URL",
 	})
 
-	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, nil, logger)
 
 	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
 	if pvc_petm == nil {
@@ -209,7 +209,7 @@ func TestCreateVolumeFromMetadata(t *testing.T) {
 		URLBase: "VOID_URL",
 	})
 
-	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, nil, logger)
 
 	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
 	if pvc_petm == nil {
@@ -291,7 +291,7 @@ func TestCreateVolumeFromMetadataAndS3(t *testing.T) {
 		URLBase: "VOID_URL",
 	})
 
-	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, nil, logger)
 
 	pvc_petm := pem.GetProtectedEntityTypeManager("pvc")
 	if pvc_petm == nil {

--- a/pkg/server/astrolabe.go
+++ b/pkg/server/astrolabe.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"github.com/labstack/echo"
+	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"net/http"
 )
@@ -29,8 +30,8 @@ type Astrolabe struct {
 	s3_services  map[string]*ServiceS3
 }
 
-func NewProtectedEntityManager(confDirPath string) astrolabe.ProtectedEntityManager {
-	dpem := NewDirectProtectedEntityManagerFromConfigDir(confDirPath)
+func NewProtectedEntityManager(confDirPath string, addonInits map[string]InitFunc, logger logrus.FieldLogger) astrolabe.ProtectedEntityManager {
+	dpem := NewDirectProtectedEntityManagerFromConfigDir(confDirPath, addonInits, logger)
 	var pem astrolabe.ProtectedEntityManager
 	pem = dpem
 	return pem


### PR DESCRIPTION
Allows for external PE types to be loaded into the ProtectedEntityManager.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>