### PR TITLE
Moved server functionality into pkg/server/server_core.go to allow for different callers with different plugin sets

### DIFF
--- a/cmd/astrolabe_server/main.go
+++ b/cmd/astrolabe_server/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the Astrolabe contributors
+ * Copyright the Astrolabe contributors
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,60 +17,9 @@
 package main
 
 import (
-	"flag"
-	"github.com/go-openapi/loads"
-	"github.com/sirupsen/logrus"
-	"github.com/vmware-tanzu/astrolabe/gen/restapi"
-	"github.com/vmware-tanzu/astrolabe/gen/restapi/operations"
 	"github.com/vmware-tanzu/astrolabe/pkg/server"
-	"os"
-	"strconv"
-
-	//"github.com/labstack/gommon/log"
-	"log"
 )
 
 func main() {
-	confDirStr := flag.String("confDir", "", "Configuration directory")
-	apiPortStr := flag.String("apiPort", "1323", "REST API port")
-	insecure := flag.Bool("insecure", false, "Only use HTTP")
-	flag.Parse()
-	if *confDirStr == "" {
-		log.Println("confDir is not defined")
-		flag.Usage()
-		return
-	}
-	apiPort, err := strconv.Atoi(*apiPortStr)
-	if err != nil {
-		log.Printf("apiPort %s is not an integer\n", *apiPortStr)
-		os.Exit(1)
-	}
-	pem := server.NewProtectedEntityManager(*confDirStr, nil, logrus.StandardLogger())
-	tm := server.NewTaskManager()
-	apiHandler := server.NewOpenAPIAstrolabeHandler(pem, tm)
-	// load embedded swagger file
-	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	// create new service API
-	api := operations.NewAstrolabeAPI(swaggerSpec)
-	server := restapi.NewServer(api)
-	if *insecure {
-		server.EnabledListeners = []string{"http"}
-	}
-	defer server.Shutdown()
-
-	// parse flags
-	flag.Parse()
-	// set the port this service will be run on
-	server.Port = apiPort
-
-	apiHandler.AttachHandlers(api)
-
-	// serve API
-	if err := server.Serve(); err != nil {
-		log.Fatalln(err)
-	}
+	server.ServerMain(nil)
 }

--- a/pkg/server/server_core.go
+++ b/pkg/server/server_core.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright the Astrolabe contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"flag"
+	"github.com/go-openapi/loads"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/gen/restapi"
+	"github.com/vmware-tanzu/astrolabe/gen/restapi/operations"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"log"
+	"strconv"
+)
+
+func ServerMain(addonInits map[string]InitFunc) {
+	server, _, err := ServerInit(addonInits)
+	if err != nil {
+		log.Println("Error initializing server = %v\n", err)
+		return
+	}
+	defer server.Shutdown()
+
+	// serve API
+	if err := server.Serve(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func ServerInit(addonInits map[string]InitFunc) (*restapi.Server, astrolabe.ProtectedEntityManager, error) {
+	confDirStr := flag.String("confDir", "", "Configuration directory")
+	apiPortStr := flag.String("apiPort", "1323", "REST API port")
+	insecure := flag.Bool("insecure", false, "Only use HTTP")
+	flag.Parse()
+	if *confDirStr == "" {
+		flag.Usage()
+		return nil, nil, errors.New("confDir is not defined")
+	}
+	apiPort, err := strconv.Atoi(*apiPortStr)
+	if err != nil {
+		log.Fatalln("apiPort %s is not an integer\n", *apiPortStr)
+	}
+	pem := NewProtectedEntityManager(*confDirStr, addonInits, logrus.New())
+	tm := NewTaskManager()
+	apiHandler := NewOpenAPIAstrolabeHandler(pem, tm)
+	// load embedded swagger file
+	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// create new service API
+	api := operations.NewAstrolabeAPI(swaggerSpec)
+	server := restapi.NewServer(api)
+	if *insecure {
+		server.EnabledListeners = []string{"http"}
+	}
+
+	// parse flags
+	flag.Parse()
+	// set the port this service will be run on
+	server.Port = apiPort
+
+	apiHandler.AttachHandlers(api)
+	return server, pem, nil
+}


### PR DESCRIPTION
Moved server functionality into pkg/server/server_core.go to allow for different callers with different plugin sets

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>