### PR TITLE
Ignore logout errors when reloading configuration

### DIFF
--- a/pkg/ivd/ivd_protected_entity_type_manager.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager.go
@@ -346,8 +346,8 @@ func (this *IVDProtectedEntityTypeManager) ReloadConfig(ctx context.Context, par
 			// Disconnecting older vc instance.
 			err = this.vcenter.Disconnect(ctx)
 			if err != nil {
-				this.logger.Errorf("Failed to disconnect older vcenter instance.")
-				return err
+				this.logger.Warnf("Failed to disconnect older vcenter instance," +
+					" ignoring and proceeding, err: %+v", err)
 			}
 		}
 	}


### PR DESCRIPTION
During ReloadConfiguration we currently return an error if there was a failure while disconnecting from vc(logout of vc session), as a side-effect, although the newly received credentials are valid, clients are not re-created with new credentials. Erroring out due to failures in disconnecting seems like a overkill, considering it's far more important to accept the new credentials and re-create the necessary clients. 

Signed-off-by: Deepak Kinni <dkinni@vmware.com>