### PR TITLE
Added GetBaseID function

### DIFF
--- a/pkg/astrolabe/protected_entity.go
+++ b/pkg/astrolabe/protected_entity.go
@@ -111,9 +111,19 @@ func (this ProtectedEntityID) GetPeType() string {
 	return this.peType
 }
 
+func (this ProtectedEntityID) GetBaseID() ProtectedEntityID {
+	if this.HasSnapshot() {
+		return ProtectedEntityID{
+			peType:     this.peType,
+			id:         this.id,
+			snapshotID: ProtectedEntitySnapshotID{},
+		}
+	}
+	return this
+}
+
 func (this ProtectedEntityID) GetSnapshotID() ProtectedEntitySnapshotID {
 	return this.snapshotID
-
 }
 
 func (this ProtectedEntityID) HasSnapshot() bool {


### PR DESCRIPTION
Strips snapshot ID from a Protected Entity ID if it has a snapshot ID

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>