### PR TITLE
Fixed bug in FillFromModel

### DIFF
--- a/pkg/astrolabe/protected_entity_info.go
+++ b/pkg/astrolabe/protected_entity_info.go
@@ -175,8 +175,8 @@ func (this *ProtectedEntityInfoImpl) FillFromModel(jsonStruct *models.ProtectedE
 	this.metadataTransports = convertToTransports(jsonStruct.MetadataTransports)
 	this.combinedTransports = convertToTransports(jsonStruct.CombinedTransports)
 	componentIDs := make([]ProtectedEntityID, len(jsonStruct.ComponentSpecs))
-	for curComponentNum, curComponentSpec := range componentIDs {
-		componentID, err := NewProtectedEntityIDFromString(curComponentSpec.id)
+	for curComponentNum, curComponentSpec := range jsonStruct.ComponentSpecs {
+		componentID, err := NewProtectedEntityIDFromString(string(curComponentSpec.ID))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
FillFromModel was using wrong array to iterate over (componentIDs instead of jsonStruct.ComponentSpecs)

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>