### PR TITLE
Added Delete method to ProtectedEntityTypeManager.  

### DIFF
--- a/changelogs/unreleased/097-dsmithuchida
+++ b/changelogs/unreleased/097-dsmithuchida
@@ -1,0 +1,1 @@
+Added Delete method to ProtectedEntityTypeManager.  This allows for deletion of protected entities and snapshots.

--- a/pkg/astrolabe/protected_entity_type_manager.go
+++ b/pkg/astrolabe/protected_entity_type_manager.go
@@ -35,4 +35,5 @@ type ProtectedEntityTypeManager interface {
 	GetProtectedEntities(ctx context.Context) ([]ProtectedEntityID, error)
 	Copy(ctx context.Context, pe ProtectedEntity, params map[string]map[string]interface{}, options CopyCreateOptions) (ProtectedEntity, error)
 	CopyFromInfo(ctx context.Context, info ProtectedEntityInfo, params map[string]map[string]interface{}, options CopyCreateOptions) (ProtectedEntity, error)
+	Delete(ctx context.Context, id ProtectedEntityID) error
 }

--- a/pkg/fs/fs_protected_entity_type_manager.go
+++ b/pkg/fs/fs_protected_entity_type_manager.go
@@ -170,3 +170,6 @@ func (this *FSProtectedEntityTypeManager) getDataTransports(id astrolabe.Protect
 	return data, md, combined, nil
 }
 
+func (this *FSProtectedEntityTypeManager) Delete(ctx context.Context, id astrolabe.ProtectedEntityID) error {
+	return errors.New("Not implemented")
+}

--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -249,3 +249,7 @@ func getPEIDForComponentSnapshot(sourceSnapshotID astrolabe.ProtectedEntityID, l
 	}
 	return astrolabe.NewProtectedEntityIDFromString(string(componentIDBytes))
 }
+
+func (this *PVCProtectedEntityTypeManager) Delete(ctx context.Context, id astrolabe.ProtectedEntityID) error {
+	panic("implement me")
+}


### PR DESCRIPTION
Delete method allows for deletion of protected entities and snapshots
Implemented in S3 repository

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>