### PR TITLE
Fixed bug in S3 GetProtectedEntitiesByIDPrefix

### DIFF
--- a/pkg/s3repository/repository_protected_entity_type_manager.go
+++ b/pkg/s3repository/repository_protected_entity_type_manager.go
@@ -219,7 +219,7 @@ func (this *ProtectedEntityTypeManager) GetProtectedEntitiesByIDPrefix(ctx conte
 		if !*results.IsTruncated {
 			hasMore = false
 		} else {
-			continuationToken = results.ContinuationToken
+			continuationToken = results.NextContinuationToken
 		}
 	}
 	return retPEIDs, nil


### PR DESCRIPTION
 GetProtectedEntitiesByIDPrefix was using the wrong token for continuation and was not paginating correctly

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>