### PR TITLE
Add support for migrated csi volume

### DIFF
--- a/pkg/pvc/pvc_protected_entity_type_manager.go
+++ b/pkg/pvc/pvc_protected_entity_type_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -19,6 +20,7 @@ import (
 
 type PVCProtectedEntityTypeManager struct {
 	clientSet *kubernetes.Clientset
+	dynamicClient dynamic.Interface
 	isGuest   bool
 	pem       astrolabe.ProtectedEntityManager
 	s3Config  astrolabe.S3Config
@@ -49,12 +51,14 @@ func NewPVCProtectedEntityTypeManagerFromConfig(params map[string]interface{}, s
 		}
 	}
 	clientSet, err := kubernetes.NewForConfig(config)
+	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
 	_, isGuest := params["svcNamespace"]
 	return &PVCProtectedEntityTypeManager{
 		clientSet: clientSet,
+		dynamicClient: dynamicClient,
 		isGuest:   isGuest,
 		s3Config:  s3Config,
 		logger:    logger,

--- a/pkg/pvc/utils.go
+++ b/pkg/pvc/utils.go
@@ -17,6 +17,9 @@ const (
 
 	// Poll is how often to Poll an API object.
 	Poll = 2 * time.Second
+
+	// MigratedCSIVolumeAnnotation is the annotation on a pv provisoned by in-tree vcp but migrated to vsphere csi
+	MigratedCSIVolumeAnnotation = "pv.kubernetes.io/migrated-to"
 )
 
 // WaitForPersistentVolumeClaimPhase waits for a PersistentVolumeClaim to be in a specific phase or until timeout occurs, whichever comes first.


### PR DESCRIPTION
When validating the pv provisioner type, we used to restrict it to be vsphere csi, now we can add support for migrated vsphere csi, where the pv spec conforms to in-tree vcp format with "migrated-to" annotation added by vsphere csi